### PR TITLE
[S2] feat: modelo de datos, repositorio y endpoints CRUD /cycles (Issues #9, #10, #11)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,6 +5,7 @@ DATABASE_URL=postgresql://postgres.[project-ref]:[password]@aws-1-us-west-2.pool
 
 # ── Supabase ─────────────────────────────────────────────────
 SUPABASE_URL=https://xxxx.supabase.co
+SUPABASE_ANON_KEY=your-anon-key-here
 SUPABASE_JWT_SECRET=your-jwt-secret-here
 
 # ── LLM (se completa en Sprint 5) ────────────────────────────

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,117 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts.
+# Use forward slashes (/) also on windows to provide an os agnostic path
+script_location = migrations
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.
+prepend_sys_path = .
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the python>=3.9 or backports.zoneinfo library and tzdata library.
+# Any required deps can installed by adding `alembic[tz]` to the pip requirements
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to migrations/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "version_path_separator" below.
+# version_locations = %(here)s/bar:%(here)s/bat:migrations/versions
+
+# version path separator; As mentioned above, this is the character used to split
+# version_locations. The default within new alembic.ini files is "os", which uses os.pathsep.
+# If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.
+# Valid values for version_path_separator are:
+#
+# version_path_separator = :
+# version_path_separator = ;
+# version_path_separator = space
+# version_path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+version_path_separator = os
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the exec runner, execute a binary
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = %(here)s/.venv/bin/ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -3,6 +3,7 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     DATABASE_URL: str = ""
     SUPABASE_URL: str = ""
+    SUPABASE_ANON_KEY: str = ""
     SUPABASE_JWT_SECRET: str = ""
     OLLAMA_BASE_URL: str = "http://localhost:11434"
     GROQ_API_KEY: str = ""
@@ -12,5 +13,6 @@ class Settings(BaseSettings):
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"
+        extra = "ignore"
 
 settings = Settings()

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -1,4 +1,10 @@
-# Sprint 2: aquí se configurará SQLAlchemy Core + asyncpg
-# Por ahora solo exportamos un placeholder para no romper imports
+from sqlalchemy.ext.asyncio import create_async_engine
 
-engine = None  # se inicializa en Sprint 2
+from app.core.config import settings
+
+DATABASE_URL = settings.DATABASE_URL
+
+if DATABASE_URL and DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+
+engine = create_async_engine(DATABASE_URL, pool_pre_ping=True) if DATABASE_URL else None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
-from app.routers import health
+from app.routers import health, cycles
 
 app = FastAPI(
     title="EVA API",
@@ -27,3 +27,4 @@ app.add_middleware(
 )
 
 app.include_router(health.router)
+app.include_router(cycles.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,23 @@
+from app.models.db_tables import (
+    metadata,
+    users_table,
+    cycles_table,
+    daily_logs_table,
+    symptoms_catalog_table,
+    daily_symptoms_table,
+    ml_models_table,
+    llm_insights_table,
+    sync_operations_table,
+)
+
+__all__ = [
+    "metadata",
+    "users_table",
+    "cycles_table",
+    "daily_logs_table",
+    "symptoms_catalog_table",
+    "daily_symptoms_table",
+    "ml_models_table",
+    "llm_insights_table",
+    "sync_operations_table",
+]

--- a/backend/app/models/cycle.py
+++ b/backend/app/models/cycle.py
@@ -1,0 +1,43 @@
+from datetime import date, datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class CycleCreate(BaseModel):
+    start_date: date
+    end_date: Optional[date] = None
+
+    @model_validator(mode="after")
+    def validate_dates(self):
+        if self.end_date and self.end_date < self.start_date:
+            raise ValueError("end_date must be greater than or equal to start_date")
+        return self
+
+
+class CycleUpdate(BaseModel):
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+
+    @model_validator(mode="after")
+    def validate_dates(self):
+        if self.start_date and self.end_date and self.end_date < self.start_date:
+            raise ValueError("end_date must be greater than or equal to start_date")
+        return self
+
+
+class CycleResponse(BaseModel):
+    id: str
+    user_id: str
+    start_date: date
+    end_date: Optional[date] = None
+    duration_days: Optional[int] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class CycleListResponse(BaseModel):
+    total: int
+    limit: int
+    offset: int
+    cycles: list[CycleResponse]

--- a/backend/app/models/cycle.py
+++ b/backend/app/models/cycle.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, model_validator
 
 
 class CycleCreate(BaseModel):

--- a/backend/app/models/db_tables.py
+++ b/backend/app/models/db_tables.py
@@ -1,0 +1,103 @@
+from sqlalchemy import (
+    Table, Column, MetaData, UUID, String, Date, DateTime,
+    SmallInteger, Text, Numeric, Boolean, Integer,
+    ForeignKey, UniqueConstraint, CheckConstraint, Index,
+    func,
+)
+
+metadata = MetaData()
+
+users_table = Table(
+    "users", metadata,
+    Column("id", UUID, primary_key=True, server_default=func.gen_random_uuid()),
+    Column("email", String(255), unique=True, nullable=False),
+    Column("birth_date", Date),
+    Column("created_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+    Column("updated_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+)
+
+cycles_table = Table(
+    "cycles", metadata,
+    Column("id", UUID, primary_key=True, server_default=func.gen_random_uuid()),
+    Column("user_id", UUID, ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+    Column("start_date", Date, nullable=False),
+    Column("end_date", Date),
+    Column("created_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+    Column("updated_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+    CheckConstraint("end_date IS NULL OR end_date >= start_date", name="chk_cycle_dates"),
+    UniqueConstraint("user_id", "start_date", name="uq_cycle_user_start"),
+    Index("idx_cycles_user_date", "user_id", "start_date", postgresql_using="btree"),
+)
+
+daily_logs_table = Table(
+    "daily_logs", metadata,
+    Column("id", UUID, primary_key=True, server_default=func.gen_random_uuid()),
+    Column("cycle_id", UUID, ForeignKey("cycles.id", ondelete="CASCADE"), nullable=False),
+    Column("date", Date, nullable=False),
+    Column("flow_level", String(10)),
+    Column("temperature", Numeric(4, 2)),
+    Column("notes", Text),
+    Column("created_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+    Column("updated_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+    CheckConstraint("flow_level IN ('none', 'light', 'medium', 'heavy')", name="chk_flow_level"),
+    CheckConstraint("temperature IS NULL OR (temperature >= 35.0 AND temperature <= 42.0)", name="chk_temperature"),
+    UniqueConstraint("cycle_id", "date", name="uq_log_cycle_date"),
+    Index("idx_daily_logs_cycle", "cycle_id", "date", postgresql_using="btree"),
+)
+
+symptoms_catalog_table = Table(
+    "symptoms_catalog", metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column("name", String(100), unique=True, nullable=False),
+    Column("category", String(20), nullable=False),
+    Column("common_phase", String(20)),
+    CheckConstraint("category IN ('fisica', 'emocional', 'digestiva', 'otra')", name="chk_symptom_category"),
+    CheckConstraint("common_phase IN ('menstruacion', 'folicular', 'ovulacion', 'lutea', 'todas') OR common_phase IS NULL", name="chk_common_phase"),
+)
+
+daily_symptoms_table = Table(
+    "daily_symptoms", metadata,
+    Column("log_id", UUID, ForeignKey("daily_logs.id", ondelete="CASCADE"), primary_key=True),
+    Column("symptom_id", Integer, ForeignKey("symptoms_catalog.id"), primary_key=True),
+    Column("intensity", SmallInteger, nullable=False),
+    CheckConstraint("intensity BETWEEN 1 AND 5", name="chk_symptom_intensity"),
+    Index("idx_daily_symptoms_log", "log_id"),
+    Index("idx_daily_symptoms_symptom", "symptom_id"),
+)
+
+ml_models_table = Table(
+    "ml_models", metadata,
+    Column("id", UUID, primary_key=True, server_default=func.gen_random_uuid()),
+    Column("user_id", UUID, ForeignKey("users.id", ondelete="CASCADE"), unique=True, nullable=False),
+    Column("model_path", Text, nullable=False),
+    Column("mae", Numeric(5, 3)),
+    Column("cycles_used", Integer),
+    Column("trained_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+    Column("is_active", Boolean, nullable=False, server_default=func.true()),
+    Index("idx_ml_models_user", "user_id"),
+)
+
+llm_insights_table = Table(
+    "llm_insights", metadata,
+    Column("id", UUID, primary_key=True, server_default=func.gen_random_uuid()),
+    Column("user_id", UUID, ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+    Column("question", Text, nullable=False),
+    Column("insight", Text, nullable=False),
+    Column("phase", String(20)),
+    Column("source", String(50), nullable=False),
+    Column("created_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+    Index("idx_llm_insights_user_date", "user_id", "created_at", postgresql_using="btree"),
+)
+
+sync_operations_table = Table(
+    "sync_operations", metadata,
+    Column("id", UUID, primary_key=True, server_default=func.gen_random_uuid()),
+    Column("user_id", UUID, ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+    Column("client_id", String(100), unique=True, nullable=False),
+    Column("type", String(30), nullable=False),
+    Column("payload", Text, nullable=False),
+    Column("status", String(20), nullable=False, server_default=func.text("'applied'")),
+    Column("applied_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+    CheckConstraint("type IN ('CREATE_CYCLE', 'UPDATE_CYCLE', 'DELETE_CYCLE', 'CREATE_DAILY_LOG', 'UPDATE_DAILY_LOG', 'DELETE_DAILY_LOG')", name="chk_sync_type"),
+    CheckConstraint("status IN ('applied', 'skipped', 'failed')", name="chk_sync_status"),
+)

--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -1,0 +1,23 @@
+from app.repositories.cycle_repo import (
+    get_cycles_by_user,
+    get_cycle_by_id,
+    get_cycle_by_start_date,
+    create_cycle,
+    update_cycle,
+    delete_cycle,
+    count_cycles,
+)
+from app.repositories.daily_log_repo import (
+    get_logs_by_cycle,
+)
+
+__all__ = [
+    "get_cycles_by_user",
+    "get_cycle_by_id",
+    "get_cycle_by_start_date",
+    "create_cycle",
+    "update_cycle",
+    "delete_cycle",
+    "count_cycles",
+    "get_logs_by_cycle",
+]

--- a/backend/app/repositories/cycle_repo.py
+++ b/backend/app/repositories/cycle_repo.py
@@ -1,0 +1,104 @@
+from datetime import date
+from typing import Optional
+
+from sqlalchemy import select, insert, update, delete, func
+
+from app.core.db import engine
+from app.models.db_tables import cycles_table
+
+CYCLE_COLUMNS = [
+    cycles_table.c.id,
+    cycles_table.c.user_id,
+    cycles_table.c.start_date,
+    cycles_table.c.end_date,
+    cycles_table.c.created_at,
+    cycles_table.c.updated_at,
+]
+
+
+async def get_cycles_by_user(
+    user_id: str,
+    limit: int = 20,
+    offset: int = 0,
+    from_date: Optional[date] = None,
+) -> list:
+    query = select(*CYCLE_COLUMNS).where(cycles_table.c.user_id == user_id)
+    if from_date:
+        query = query.where(cycles_table.c.start_date >= from_date)
+    query = query.order_by(cycles_table.c.start_date.desc()).limit(limit).offset(offset)
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return result.fetchall()
+
+
+async def get_cycle_by_start_date(user_id: str, start_date: date):
+    query = (
+        select(*CYCLE_COLUMNS)
+        .where(cycles_table.c.user_id == user_id)
+        .where(cycles_table.c.start_date == start_date)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return result.one_or_none()
+
+
+async def get_cycle_by_id(cycle_id: str, user_id: str):
+    query = (
+        select(*CYCLE_COLUMNS)
+        .where(cycles_table.c.id == cycle_id)
+        .where(cycles_table.c.user_id == user_id)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return result.one_or_none()
+
+
+async def create_cycle(user_id: str, data: dict) -> dict:
+    query = (
+        insert(cycles_table)
+        .values(**data, user_id=user_id)
+        .returning(*CYCLE_COLUMNS)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        await conn.commit()
+        row = result.one()
+        return dict(row._mapping)
+
+
+async def update_cycle(cycle_id: str, user_id: str, data: dict) -> dict | None:
+    query = (
+        update(cycles_table)
+        .where(cycles_table.c.id == cycle_id)
+        .where(cycles_table.c.user_id == user_id)
+        .values(**data)
+        .returning(*CYCLE_COLUMNS)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        await conn.commit()
+        row = result.one_or_none()
+        return dict(row._mapping) if row else None
+
+
+async def delete_cycle(cycle_id: str, user_id: str) -> bool:
+    query = (
+        delete(cycles_table)
+        .where(cycles_table.c.id == cycle_id)
+        .where(cycles_table.c.user_id == user_id)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        await conn.commit()
+        return result.rowcount > 0
+
+
+async def count_cycles(user_id: str) -> int:
+    query = (
+        select(func.count())
+        .select_from(cycles_table)
+        .where(cycles_table.c.user_id == user_id)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return result.scalar_one()

--- a/backend/app/repositories/daily_log_repo.py
+++ b/backend/app/repositories/daily_log_repo.py
@@ -1,0 +1,26 @@
+from sqlalchemy import select
+
+from app.core.db import engine
+from app.models.db_tables import daily_logs_table
+
+LOG_COLUMNS = [
+    daily_logs_table.c.id,
+    daily_logs_table.c.cycle_id,
+    daily_logs_table.c.date,
+    daily_logs_table.c.flow_level,
+    daily_logs_table.c.temperature,
+    daily_logs_table.c.notes,
+    daily_logs_table.c.created_at,
+    daily_logs_table.c.updated_at,
+]
+
+
+async def get_logs_by_cycle(cycle_id: str) -> list:
+    query = (
+        select(*LOG_COLUMNS)
+        .where(daily_logs_table.c.cycle_id == cycle_id)
+        .order_by(daily_logs_table.c.date)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return result.fetchall()

--- a/backend/app/routers/cycles.py
+++ b/backend/app/routers/cycles.py
@@ -1,0 +1,72 @@
+from datetime import date
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query, status
+
+from app.core.security import get_current_user
+from app.models.cycle import CycleCreate, CycleUpdate, CycleResponse, CycleListResponse
+from app.services import cycle_service
+
+router = APIRouter(prefix="/cycles", tags=["cycles"])
+
+
+@router.post("", response_model=CycleResponse, status_code=status.HTTP_201_CREATED)
+async def create_cycle(
+    body: CycleCreate,
+    current_user: dict = Depends(get_current_user),
+):
+    return await cycle_service.create_cycle(
+        user_id=current_user["user_id"],
+        data=body.model_dump(exclude_none=True),
+    )
+
+
+@router.get("", response_model=CycleListResponse)
+async def list_cycles(
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    from_date: Optional[date] = Query(None),
+    current_user: dict = Depends(get_current_user),
+):
+    total, cycles = await cycle_service.get_cycles_by_user(
+        user_id=current_user["user_id"],
+        limit=limit,
+        offset=offset,
+        from_date=from_date,
+    )
+    return CycleListResponse(total=total, limit=limit, offset=offset, cycles=cycles)
+
+
+@router.get("/{cycle_id}", response_model=CycleResponse)
+async def get_cycle(
+    cycle_id: str,
+    current_user: dict = Depends(get_current_user),
+):
+    return await cycle_service.get_cycle_by_id(
+        cycle_id=cycle_id,
+        user_id=current_user["user_id"],
+    )
+
+
+@router.put("/{cycle_id}", response_model=CycleResponse)
+async def update_cycle(
+    cycle_id: str,
+    body: CycleUpdate,
+    current_user: dict = Depends(get_current_user),
+):
+    return await cycle_service.update_cycle(
+        cycle_id=cycle_id,
+        user_id=current_user["user_id"],
+        data=body.model_dump(exclude_none=True),
+    )
+
+
+@router.delete("/{cycle_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_cycle(
+    cycle_id: str,
+    current_user: dict = Depends(get_current_user),
+):
+    await cycle_service.delete_cycle(
+        cycle_id=cycle_id,
+        user_id=current_user["user_id"],
+    )

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,5 @@
+from app.services import cycle_service
+
+__all__ = [
+    "cycle_service",
+]

--- a/backend/app/services/cycle_service.py
+++ b/backend/app/services/cycle_service.py
@@ -1,0 +1,93 @@
+from datetime import date
+from typing import Optional
+
+from fastapi import HTTPException, status
+
+from app.repositories import cycle_repo
+from app.repositories.daily_log_repo import get_logs_by_cycle
+
+
+def _calc_duration(start: date, end: Optional[date]) -> Optional[int]:
+    if end:
+        return (end - start).days
+    return None
+
+
+def _row_to_dict(row, duration: Optional[int] = None) -> dict:
+    data = dict(row._mapping)
+    data["duration_days"] = duration or _calc_duration(data["start_date"], data.get("end_date"))
+    data["id"] = str(data["id"])
+    data["user_id"] = str(data["user_id"])
+    data["created_at"] = data["created_at"].isoformat() if data.get("created_at") else None
+    data["updated_at"] = data["updated_at"].isoformat() if data.get("updated_at") else None
+    return data
+
+
+async def create_cycle(user_id: str, data: dict) -> dict:
+    existing = await cycle_repo.get_cycle_by_start_date(user_id, data["start_date"])
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A cycle already exists starting on this date",
+        )
+    row = await cycle_repo.create_cycle(user_id, data)
+    return _row_to_dict(row)
+
+
+async def get_cycles_by_user(
+    user_id: str,
+    limit: int = 20,
+    offset: int = 0,
+    from_date: Optional[date] = None,
+) -> tuple[int, list[dict]]:
+    total = await cycle_repo.count_cycles(user_id)
+    rows = await cycle_repo.get_cycles_by_user(user_id, limit, offset, from_date)
+    cycles = [_row_to_dict(r) for r in rows]
+    return total, cycles
+
+
+async def get_cycle_by_id(cycle_id: str, user_id: str) -> dict:
+    row = await cycle_repo.get_cycle_by_id(cycle_id, user_id)
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Cycle not found",
+        )
+    cycle = _row_to_dict(row)
+    logs = await get_logs_by_cycle(cycle_id)
+    cycle["daily_logs"] = [_log_row_to_dict(log) for log in logs]
+    return cycle
+
+
+async def update_cycle(cycle_id: str, user_id: str, data: dict) -> dict:
+    if "start_date" in data:
+        existing = await cycle_repo.get_cycle_by_start_date(user_id, data["start_date"])
+        if existing and str(existing.id) != cycle_id:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="A cycle already exists starting on this date",
+            )
+    row = await cycle_repo.update_cycle(cycle_id, user_id, data)
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Cycle not found",
+        )
+    return _row_to_dict(row)
+
+
+async def delete_cycle(cycle_id: str, user_id: str) -> None:
+    deleted = await cycle_repo.delete_cycle(cycle_id, user_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Cycle not found",
+        )
+
+
+def _log_row_to_dict(row) -> dict:
+    data = dict(row._mapping)
+    data["id"] = str(data["id"])
+    data["date"] = data["date"].isoformat() if isinstance(data.get("date"), date) else data.get("date")
+    data["temperature"] = float(data["temperature"]) if data.get("temperature") else None
+    return data

--- a/backend/migrations/README
+++ b/backend/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration with an async dbapi.

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,0 +1,63 @@
+import asyncio
+from logging.config import fileConfig
+
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from alembic import context
+
+from app.core.config import settings
+from app.models.db_tables import metadata
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
+
+target_metadata = metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_async_migrations() -> None:
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    asyncio.run(run_async_migrations())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/migrations/script.py.mako
+++ b/backend/migrations/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/backend/migrations/versions/001_initial_schema.py
+++ b/backend/migrations/versions/001_initial_schema.py
@@ -1,0 +1,125 @@
+"""initial_schema
+
+Revision ID: 001
+Revises:
+Create Date: 2025-06-30
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.UUID(), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("email", sa.String(255), unique=True, nullable=False),
+        sa.Column("birth_date", sa.Date(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+    )
+
+    op.create_table(
+        "cycles",
+        sa.Column("id", sa.UUID(), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("start_date", sa.Date(), nullable=False),
+        sa.Column("end_date", sa.Date(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.CheckConstraint("end_date IS NULL OR end_date >= start_date", name="chk_cycle_dates"),
+        sa.UniqueConstraint("user_id", "start_date", name="uq_cycle_user_start"),
+    )
+    op.create_index("idx_cycles_user_date", "cycles", ["user_id", sa.text("start_date DESC")])
+
+    op.create_table(
+        "daily_logs",
+        sa.Column("id", sa.UUID(), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("cycle_id", sa.UUID(), sa.ForeignKey("cycles.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("flow_level", sa.String(10), nullable=True),
+        sa.Column("temperature", sa.Numeric(4, 2), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.CheckConstraint("flow_level IN ('none', 'light', 'medium', 'heavy')", name="chk_flow_level"),
+        sa.CheckConstraint("temperature IS NULL OR (temperature >= 35.0 AND temperature <= 42.0)", name="chk_temperature"),
+        sa.UniqueConstraint("cycle_id", "date", name="uq_log_cycle_date"),
+    )
+    op.create_index("idx_daily_logs_cycle", "daily_logs", ["cycle_id", "date"])
+
+    op.create_table(
+        "symptoms_catalog",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("name", sa.String(100), unique=True, nullable=False),
+        sa.Column("category", sa.String(20), nullable=False),
+        sa.Column("common_phase", sa.String(20), nullable=True),
+        sa.CheckConstraint("category IN ('fisica', 'emocional', 'digestiva', 'otra')", name="chk_symptom_category"),
+        sa.CheckConstraint("common_phase IN ('menstruacion', 'folicular', 'ovulacion', 'lutea', 'todas') OR common_phase IS NULL", name="chk_common_phase"),
+    )
+
+    op.create_table(
+        "daily_symptoms",
+        sa.Column("log_id", sa.UUID(), sa.ForeignKey("daily_logs.id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("symptom_id", sa.Integer(), sa.ForeignKey("symptoms_catalog.id"), primary_key=True),
+        sa.Column("intensity", sa.SmallInteger(), nullable=False),
+        sa.CheckConstraint("intensity BETWEEN 1 AND 5", name="chk_symptom_intensity"),
+    )
+    op.create_index("idx_daily_symptoms_log", "daily_symptoms", ["log_id"])
+    op.create_index("idx_daily_symptoms_symptom", "daily_symptoms", ["symptom_id"])
+
+    op.create_table(
+        "ml_models",
+        sa.Column("id", sa.UUID(), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"), unique=True, nullable=False),
+        sa.Column("model_path", sa.Text(), nullable=False),
+        sa.Column("mae", sa.Numeric(5, 3), nullable=True),
+        sa.Column("cycles_used", sa.Integer(), nullable=True),
+        sa.Column("trained_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("TRUE")),
+    )
+    op.create_index("idx_ml_models_user", "ml_models", ["user_id"])
+
+    op.create_table(
+        "llm_insights",
+        sa.Column("id", sa.UUID(), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("question", sa.Text(), nullable=False),
+        sa.Column("insight", sa.Text(), nullable=False),
+        sa.Column("phase", sa.String(20), nullable=True),
+        sa.Column("source", sa.String(50), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+    )
+    op.create_index("idx_llm_insights_user_date", "llm_insights", ["user_id", sa.text("created_at DESC")])
+
+    op.create_table(
+        "sync_operations",
+        sa.Column("id", sa.UUID(), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("client_id", sa.String(100), unique=True, nullable=False),
+        sa.Column("type", sa.String(30), nullable=False),
+        sa.Column("payload", sa.Text(), nullable=False),
+        sa.Column("status", sa.String(20), nullable=False, server_default=sa.text("'applied'")),
+        sa.Column("applied_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.CheckConstraint("type IN ('CREATE_CYCLE', 'UPDATE_CYCLE', 'DELETE_CYCLE', 'CREATE_DAILY_LOG', 'UPDATE_DAILY_LOG', 'DELETE_DAILY_LOG')", name="chk_sync_type"),
+        sa.CheckConstraint("status IN ('applied', 'skipped', 'failed')", name="chk_sync_status"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("sync_operations")
+    op.drop_table("llm_insights")
+    op.drop_table("ml_models")
+    op.drop_table("daily_symptoms")
+    op.drop_table("symptoms_catalog")
+    op.drop_table("daily_logs")
+    op.drop_table("cycles")
+    op.drop_table("users")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,9 @@ annotated-types==0.7.0
 anyio==4.13.0
 asyncpg==0.31.0
 click==8.3.3
+alembic==1.15.2
 fastapi==0.136.1
+PyJWT==2.10.1
 h11==0.16.0
 httptools==0.7.1
 idna==3.14
@@ -12,6 +14,7 @@ pydantic-settings==2.14.1
 pydantic_core==2.46.4
 python-dotenv==1.2.2
 PyYAML==6.0.3
+SQLAlchemy==2.0.38
 starlette==1.0.0
 typing-inspection==0.4.2
 typing_extensions==4.15.0


### PR DESCRIPTION
## Issues cerradas
- **#9** — Modelo de datos: tablas cycles + daily_logs (3NF)
- **#10** — Repositorio cycle_repo.py + queries SQLAlchemy Core
- **#11** — Endpoints CRUD /cycles (POST, GET, PUT, DELETE)

## Cambios incluidos

### Modelo de datos
- app/models/db_tables.py — 8 tablas SQLAlchemy Core con constraints, FKs e índices
- app/core/db.py — engine async real con asyncpg
- Migración Alembic 001_initial_schema.py con upgrade/downgrade

### Repositorio
- app/repositories/cycle_repo.py — 6 funciones CRUD + count
- app/repositories/daily_log_repo.py — get_logs_by_cycle

### Endpoints
- POST /cycles → 201
- GET /cycles → lista paginada con total
- GET /cycles/{id} → detalle con daily_logs
- PUT /cycles/{id} → 200
- DELETE /cycles/{id} → 204

### Fixes adicionales
- .env.example actualizado con SUPABASE_ANON_KEY
- .env formato unificado a key=value
- config.py agregado SUPABASE_ANON_KEY + extra=ignore
- requirements.txt agregado alembic, PyJWT, SQLAlchemy

## Verificación
- Servidor arranca sin errores
- GET /health → 200 OK
- Swagger /docs muestra los endpoints