### PR TITLE
[S3] feat: endpoints CRUD /symptoms y /daily-logs

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,12 @@
 # ── Base de datos ────────────────────────────────────────────
 # Pooler (IPv4 compatible) — para desarrollo local
-# En producción (Render) usar la conexión directa si IPv6 está disponible
+# En produccion (Render) usar la conexion directa si IPv6 esta disponible
 DATABASE_URL=postgresql://postgres.[project-ref]:[password]@aws-1-us-west-2.pooler.supabase.com:6543/postgres
+
+# ── Base de datos de pruebas ─────────────────────────────────
+# Usar la misma instancia de Supabase con un schema separado
+# Si no se define, los tests de integracion usaran DATABASE_URL
+# TEST_DATABASE_URL=postgresql://postgres.[project-ref]:[password]@aws-1-us-west-2.pooler.supabase.com:6543/postgres
 
 # ── Supabase ─────────────────────────────────────────────────
 SUPABASE_URL=https://xxxx.supabase.co

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -2,6 +2,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     DATABASE_URL: str = ""
+    TEST_DATABASE_URL: str = ""
     SUPABASE_URL: str = ""
     SUPABASE_ANON_KEY: str = ""
     SUPABASE_JWT_SECRET: str = ""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
-from app.routers import health, cycles
+from app.routers import health, cycles, symptoms
 
 app = FastAPI(
     title="EVA API",
@@ -28,3 +28,5 @@ app.add_middleware(
 
 app.include_router(health.router)
 app.include_router(cycles.router)
+app.include_router(symptoms.symptoms_router)
+app.include_router(symptoms.daily_logs_router)

--- a/backend/app/models/symptom.py
+++ b/backend/app/models/symptom.py
@@ -1,0 +1,72 @@
+from datetime import date, datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class SymptomEntry(BaseModel):
+    symptom_id: int
+    intensity: int = Field(ge=1, le=5)
+
+
+class SymptomResponse(BaseModel):
+    id: int
+    name: str
+    category: str
+    common_phase: Optional[str] = None
+
+
+class SymptomLogEntry(BaseModel):
+    symptom_id: int
+    intensity: int
+    name: str
+    category: str
+    common_phase: Optional[str] = None
+
+
+class DailyLogCreate(BaseModel):
+    cycle_id: str
+    date: date
+    flow_level: Optional[str] = None
+    temperature: Optional[float] = Field(None, ge=35.0, le=42.0)
+    notes: Optional[str] = None
+    symptoms: list[SymptomEntry] = []
+
+    @model_validator(mode="after")
+    def validate_flow_level(self):
+        if self.flow_level and self.flow_level not in ("none", "light", "medium", "heavy"):
+            raise ValueError("flow_level must be one of: none, light, medium, heavy")
+        return self
+
+
+class DailyLogUpdate(BaseModel):
+    date: Optional[date] = None
+    flow_level: Optional[str] = None
+    temperature: Optional[float] = Field(None, ge=35.0, le=42.0)
+    notes: Optional[str] = None
+    symptoms: Optional[list[SymptomEntry]] = None
+
+    @model_validator(mode="after")
+    def validate_flow_level(self):
+        if self.flow_level and self.flow_level not in ("none", "light", "medium", "heavy"):
+            raise ValueError("flow_level must be one of: none, light, medium, heavy")
+        return self
+
+
+class DailyLogResponse(BaseModel):
+    id: str
+    cycle_id: str
+    date: date
+    flow_level: Optional[str] = None
+    temperature: Optional[float] = None
+    notes: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+    symptoms: list[SymptomLogEntry] = []
+
+
+class DailyLogListResponse(BaseModel):
+    total: int
+    limit: int
+    offset: int
+    logs: list[DailyLogResponse]

--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -9,6 +9,21 @@ from app.repositories.cycle_repo import (
 )
 from app.repositories.daily_log_repo import (
     get_logs_by_cycle,
+    get_logs_by_cycle_paginated,
+    create_daily_log,
+    get_daily_log_by_id,
+    get_daily_log_by_date,
+    update_daily_log,
+    delete_daily_log,
+    count_logs_by_cycle,
+)
+from app.repositories.symptom_repo import (
+    get_all_symptoms,
+    get_symptom_by_id,
+    get_symptoms_by_log,
+    add_symptoms_to_log,
+    remove_symptoms_from_log,
+    remove_all_symptoms_from_log,
 )
 
 __all__ = [
@@ -20,4 +35,17 @@ __all__ = [
     "delete_cycle",
     "count_cycles",
     "get_logs_by_cycle",
+    "get_logs_by_cycle_paginated",
+    "create_daily_log",
+    "get_daily_log_by_id",
+    "get_daily_log_by_date",
+    "update_daily_log",
+    "delete_daily_log",
+    "count_logs_by_cycle",
+    "get_all_symptoms",
+    "get_symptom_by_id",
+    "get_symptoms_by_log",
+    "add_symptoms_to_log",
+    "remove_symptoms_from_log",
+    "remove_all_symptoms_from_log",
 ]

--- a/backend/app/repositories/daily_log_repo.py
+++ b/backend/app/repositories/daily_log_repo.py
@@ -1,4 +1,6 @@
-from sqlalchemy import select
+from datetime import date
+
+from sqlalchemy import select, insert, update, delete, func
 
 from app.core.db import engine
 from app.models.db_tables import daily_logs_table
@@ -24,3 +26,78 @@ async def get_logs_by_cycle(cycle_id: str) -> list:
     async with engine.connect() as conn:
         result = await conn.execute(query)
         return result.fetchall()
+
+
+async def get_logs_by_cycle_paginated(
+    cycle_id: str, limit: int = 50, offset: int = 0
+) -> list:
+    query = (
+        select(*LOG_COLUMNS)
+        .where(daily_logs_table.c.cycle_id == cycle_id)
+        .order_by(daily_logs_table.c.date)
+        .limit(limit)
+        .offset(offset)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return result.fetchall()
+
+
+async def create_daily_log(data: dict) -> dict:
+    query = insert(daily_logs_table).values(**data).returning(*LOG_COLUMNS)
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        await conn.commit()
+        row = result.one()
+        return dict(row._mapping)
+
+
+async def get_daily_log_by_id(log_id: str):
+    query = select(*LOG_COLUMNS).where(daily_logs_table.c.id == log_id)
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return result.one_or_none()
+
+
+async def get_daily_log_by_date(cycle_id: str, log_date: date):
+    query = (
+        select(*LOG_COLUMNS)
+        .where(daily_logs_table.c.cycle_id == cycle_id)
+        .where(daily_logs_table.c.date == log_date)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return result.one_or_none()
+
+
+async def update_daily_log(log_id: str, data: dict) -> dict | None:
+    query = (
+        update(daily_logs_table)
+        .where(daily_logs_table.c.id == log_id)
+        .values(**data)
+        .returning(*LOG_COLUMNS)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        await conn.commit()
+        row = result.one_or_none()
+        return dict(row._mapping) if row else None
+
+
+async def delete_daily_log(log_id: str) -> bool:
+    query = delete(daily_logs_table).where(daily_logs_table.c.id == log_id)
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        await conn.commit()
+        return result.rowcount > 0
+
+
+async def count_logs_by_cycle(cycle_id: str) -> int:
+    query = (
+        select(func.count())
+        .select_from(daily_logs_table)
+        .where(daily_logs_table.c.cycle_id == cycle_id)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return result.scalar_one()

--- a/backend/app/repositories/symptom_repo.py
+++ b/backend/app/repositories/symptom_repo.py
@@ -1,0 +1,80 @@
+from sqlalchemy import select, insert, delete
+from app.core.db import engine
+from app.models.db_tables import symptoms_catalog_table, daily_symptoms_table
+
+CATALOG_COLUMNS = [
+    symptoms_catalog_table.c.id,
+    symptoms_catalog_table.c.name,
+    symptoms_catalog_table.c.category,
+    symptoms_catalog_table.c.common_phase,
+]
+
+DAILY_SYMPTOM_COLUMNS = [
+    daily_symptoms_table.c.log_id,
+    daily_symptoms_table.c.symptom_id,
+    daily_symptoms_table.c.intensity,
+]
+
+
+async def get_all_symptoms() -> list:
+    query = select(*CATALOG_COLUMNS).order_by(symptoms_catalog_table.c.category, symptoms_catalog_table.c.name)
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return result.fetchall()
+
+
+async def get_symptom_by_id(symptom_id: int):
+    query = select(*CATALOG_COLUMNS).where(symptoms_catalog_table.c.id == symptom_id)
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return result.one_or_none()
+
+
+async def get_symptoms_by_log(log_id: str) -> list:
+    join_cols = [
+        daily_symptoms_table.c.symptom_id,
+        daily_symptoms_table.c.intensity,
+        symptoms_catalog_table.c.name,
+        symptoms_catalog_table.c.category,
+        symptoms_catalog_table.c.common_phase,
+    ]
+    query = (
+        select(*join_cols)
+        .select_from(daily_symptoms_table.join(symptoms_catalog_table))
+        .where(daily_symptoms_table.c.log_id == log_id)
+        .order_by(symptoms_catalog_table.c.category, symptoms_catalog_table.c.name)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return result.fetchall()
+
+
+async def add_symptoms_to_log(log_id: str, symptoms: list[dict]) -> list:
+    rows = [
+        {"log_id": log_id, "symptom_id": s["symptom_id"], "intensity": s["intensity"]}
+        for s in symptoms
+    ]
+    query = insert(daily_symptoms_table).values(rows).returning(*DAILY_SYMPTOM_COLUMNS)
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        await conn.commit()
+        return result.fetchall()
+
+
+async def remove_symptoms_from_log(log_id: str, symptom_ids: list[int]) -> bool:
+    query = delete(daily_symptoms_table).where(
+        daily_symptoms_table.c.log_id == log_id,
+        daily_symptoms_table.c.symptom_id.in_(symptom_ids),
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        await conn.commit()
+        return result.rowcount > 0
+
+
+async def remove_all_symptoms_from_log(log_id: str) -> bool:
+    query = delete(daily_symptoms_table).where(daily_symptoms_table.c.log_id == log_id)
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        await conn.commit()
+        return result.rowcount > 0

--- a/backend/app/routers/symptoms.py
+++ b/backend/app/routers/symptoms.py
@@ -1,0 +1,87 @@
+from fastapi import APIRouter, Depends, Query, status
+
+from app.core.security import get_current_user
+from app.models.symptom import (
+    SymptomResponse,
+    DailyLogCreate,
+    DailyLogUpdate,
+    DailyLogResponse,
+    DailyLogListResponse,
+)
+from app.services import symptom_service
+
+symptoms_router = APIRouter(prefix="/symptoms", tags=["symptoms"])
+
+daily_logs_router = APIRouter(prefix="/daily-logs", tags=["daily-logs"])
+
+
+@symptoms_router.get("", response_model=list[SymptomResponse])
+async def list_symptoms():
+    return await symptom_service.list_symptoms()
+
+
+@symptoms_router.get("/{symptom_id}", response_model=SymptomResponse)
+async def get_symptom(symptom_id: int):
+    return await symptom_service.get_symptom(symptom_id)
+
+
+@daily_logs_router.post("", response_model=DailyLogResponse, status_code=status.HTTP_201_CREATED)
+async def create_daily_log(
+    body: DailyLogCreate,
+    current_user: dict = Depends(get_current_user),
+):
+    return await symptom_service.create_log(
+        data=body.model_dump(exclude_none=True),
+        user_id=current_user["user_id"],
+    )
+
+
+@daily_logs_router.get("", response_model=DailyLogListResponse)
+async def list_daily_logs(
+    cycle_id: str = Query(...),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    current_user: dict = Depends(get_current_user),
+):
+    total, logs = await symptom_service.list_logs_by_cycle(
+        cycle_id=cycle_id,
+        user_id=current_user["user_id"],
+        limit=limit,
+        offset=offset,
+    )
+    return DailyLogListResponse(total=total, limit=limit, offset=offset, logs=logs)
+
+
+@daily_logs_router.get("/{log_id}", response_model=DailyLogResponse)
+async def get_daily_log(
+    log_id: str,
+    current_user: dict = Depends(get_current_user),
+):
+    return await symptom_service.get_log(
+        log_id=log_id,
+        user_id=current_user["user_id"],
+    )
+
+
+@daily_logs_router.put("/{log_id}", response_model=DailyLogResponse)
+async def update_daily_log(
+    log_id: str,
+    body: DailyLogUpdate,
+    current_user: dict = Depends(get_current_user),
+):
+    return await symptom_service.update_log(
+        log_id=log_id,
+        data=body.model_dump(exclude_none=True),
+        user_id=current_user["user_id"],
+    )
+
+
+@daily_logs_router.delete("/{log_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_daily_log(
+    log_id: str,
+    current_user: dict = Depends(get_current_user),
+):
+    await symptom_service.delete_log(
+        log_id=log_id,
+        user_id=current_user["user_id"],
+    )

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,5 +1,6 @@
-from app.services import cycle_service
+from app.services import cycle_service, symptom_service
 
 __all__ = [
     "cycle_service",
+    "symptom_service",
 ]

--- a/backend/app/services/symptom_service.py
+++ b/backend/app/services/symptom_service.py
@@ -1,0 +1,173 @@
+from datetime import date
+
+from fastapi import HTTPException, status
+
+from app.repositories import cycle_repo
+from app.repositories.daily_log_repo import (
+    create_daily_log as repo_create_log,
+    get_daily_log_by_id,
+    get_daily_log_by_date,
+    get_logs_by_cycle_paginated,
+    update_daily_log as repo_update_log,
+    delete_daily_log as repo_delete_log,
+    count_logs_by_cycle,
+)
+from app.repositories.symptom_repo import (
+    get_all_symptoms,
+    get_symptom_by_id,
+    get_symptoms_by_log,
+    add_symptoms_to_log,
+    remove_all_symptoms_from_log,
+)
+
+
+async def list_symptoms() -> list[dict]:
+    rows = await get_all_symptoms()
+    return [_symptom_catalog_to_dict(r) for r in rows]
+
+
+async def get_symptom(symptom_id: int) -> dict:
+    row = await get_symptom_by_id(symptom_id)
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Symptom not found",
+        )
+    return _symptom_catalog_to_dict(row)
+
+
+async def create_log(data: dict, user_id: str) -> dict:
+    cycle = await cycle_repo.get_cycle_by_id(data["cycle_id"], user_id)
+    if not cycle:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Cycle not found",
+        )
+    existing = await get_daily_log_by_date(data["cycle_id"], data["date"])
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A daily log already exists for this date in this cycle",
+        )
+    symptoms_payload = data.pop("symptoms", [])
+    row = await repo_create_log(data)
+    if symptoms_payload:
+        await add_symptoms_to_log(
+            log_id=str(row["id"]),
+            symptoms=[{"symptom_id": s["symptom_id"], "intensity": s["intensity"]} for s in symptoms_payload],
+        )
+    return await _enrich_log_with_symptoms(row)
+
+
+async def list_logs_by_cycle(
+    cycle_id: str, user_id: str, limit: int = 50, offset: int = 0
+) -> tuple[int, list[dict]]:
+    cycle = await cycle_repo.get_cycle_by_id(cycle_id, user_id)
+    if not cycle:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Cycle not found",
+        )
+    total = await count_logs_by_cycle(cycle_id)
+    rows = await get_logs_by_cycle_paginated(cycle_id, limit, offset)
+    logs = []
+    for row in rows:
+        log = _log_row_to_dict(row)
+        symptoms = await get_symptoms_by_log(log["id"])
+        log["symptoms"] = [_symptom_log_to_dict(s) for s in symptoms]
+        logs.append(log)
+    return total, logs
+
+
+async def get_log(log_id: str, user_id: str) -> dict:
+    row = await get_daily_log_by_id(log_id)
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Daily log not found",
+        )
+    await _validate_log_ownership(row, user_id)
+    return await _enrich_log_with_symptoms(row)
+
+
+async def update_log(log_id: str, data: dict, user_id: str) -> dict:
+    row = await get_daily_log_by_id(log_id)
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Daily log not found",
+        )
+    await _validate_log_ownership(row, user_id)
+    if "date" in data:
+        existing = await get_daily_log_by_date(str(row.cycle_id), data["date"])
+        if existing and str(existing.id) != log_id:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="A daily log already exists for this date in this cycle",
+            )
+    symptoms_payload = data.pop("symptoms", None)
+    updated = await repo_update_log(log_id, data)
+    if not updated:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Daily log not found",
+        )
+    if symptoms_payload is not None:
+        await remove_all_symptoms_from_log(log_id)
+        if symptoms_payload:
+            await add_symptoms_to_log(
+                log_id=log_id,
+                symptoms=[{"symptom_id": s["symptom_id"], "intensity": s["intensity"]} for s in symptoms_payload],
+            )
+    return await _enrich_log_with_symptoms(updated)
+
+
+async def delete_log(log_id: str, user_id: str) -> None:
+    row = await get_daily_log_by_id(log_id)
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Daily log not found",
+        )
+    await _validate_log_ownership(row, user_id)
+    deleted = await repo_delete_log(log_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Daily log not found",
+        )
+
+
+async def _validate_log_ownership(row, user_id: str) -> None:
+    cycle = await cycle_repo.get_cycle_by_id(str(row.cycle_id), user_id)
+    if not cycle:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Daily log not found",
+        )
+
+
+async def _enrich_log_with_symptoms(row) -> dict:
+    log = _log_row_to_dict(row)
+    symptoms = await get_symptoms_by_log(log["id"])
+    log["symptoms"] = [_symptom_log_to_dict(s) for s in symptoms]
+    return log
+
+
+def _log_row_to_dict(row) -> dict:
+    data = dict(row._mapping)
+    data["id"] = str(data["id"])
+    data["cycle_id"] = str(data["cycle_id"])
+    data["date"] = data["date"].isoformat() if isinstance(data.get("date"), date) else data.get("date")
+    data["temperature"] = float(data["temperature"]) if data.get("temperature") else None
+    data["created_at"] = data["created_at"].isoformat() if data.get("created_at") else None
+    data["updated_at"] = data["updated_at"].isoformat() if data.get("updated_at") else None
+    return data
+
+
+def _symptom_catalog_to_dict(row) -> dict:
+    return dict(row._mapping)
+
+
+def _symptom_log_to_dict(row) -> dict:
+    return dict(row._mapping)

--- a/backend/migrations/versions/002_add_symptoms_seed.py
+++ b/backend/migrations/versions/002_add_symptoms_seed.py
@@ -1,0 +1,79 @@
+"""add_symptoms_seed
+
+Revision ID: 002
+Revises: 001
+Create Date: 2025-06-30
+
+Seed del catalogo de 30 sintomas predefinidos.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "002"
+down_revision: Union[str, None] = "001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+SYMPTOMS = [
+    # Fisicos — menstruacion y lutea
+    ("Dolor abdominal (colicos)", "fisica", "menstruacion"),
+    ("Dolor lumbar", "fisica", "menstruacion"),
+    ("Dolor de cabeza / migrana", "fisica", "lutea"),
+    ("Fatiga", "fisica", "lutea"),
+    ("Sensibilidad mamaria", "fisica", "lutea"),
+    ("Hinchazon corporal", "digestiva", "lutea"),
+    ("Calambres en piernas", "fisica", "menstruacion"),
+    ("Acne / brotes en piel", "fisica", "lutea"),
+    ("Temperatura basal elevada", "fisica", "lutea"),
+    ("Insomnio / sueno alterado", "fisica", "lutea"),
+    ("Energia alta", "fisica", "folicular"),
+    ("Piel radiante", "fisica", "folicular"),
+    ("Dolor ovulatorio (Mittelschmerz)", "fisica", "ovulacion"),
+    ("Flujo abundante", "fisica", "ovulacion"),
+    ("Sofocos", "fisica", "todas"),
+    # Digestivos
+    ("Nauseas", "digestiva", "menstruacion"),
+    ("Antojos de comida", "digestiva", "lutea"),
+    ("Estrinimiento", "digestiva", "lutea"),
+    ("Diarrea", "digestiva", "menstruacion"),
+    ("Gases / distension", "digestiva", "lutea"),
+    # Emocionales
+    ("Irritabilidad", "emocional", "lutea"),
+    ("Ansiedad", "emocional", "lutea"),
+    ("Tristeza / llanto facil", "emocional", "lutea"),
+    ("Cambios de humor bruscos", "emocional", "lutea"),
+    ("Dificultad de concentracion", "emocional", "lutea"),
+    ("Baja libido", "emocional", "lutea"),
+    ("Libido alta", "emocional", "ovulacion"),
+    ("Motivacion / claridad mental", "emocional", "folicular"),
+    ("Sensacion de bienestar", "emocional", "folicular"),
+    ("Aislamiento social", "emocional", "lutea"),
+]
+
+
+def upgrade() -> None:
+    symptoms_catalog = sa.table(
+        "symptoms_catalog",
+        sa.column("name", sa.String),
+        sa.column("category", sa.String),
+        sa.column("common_phase", sa.String),
+    )
+    op.bulk_insert(
+        symptoms_catalog,
+        [
+            {"name": name, "category": category, "common_phase": phase}
+            for name, category, phase in SYMPTOMS
+        ],
+    )
+
+
+def downgrade() -> None:
+    symptoms_catalog = sa.table("symptoms_catalog", sa.column("name", sa.String))
+    names = [s[0] for s in SYMPTOMS]
+    op.execute(
+        symptoms_catalog.delete().where(symptoms_catalog.c.name.in_(names))
+    )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,177 @@
+from datetime import date
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.core.config import settings
+from app.models.db_tables import metadata, symptoms_catalog_table
+
+TEST_USER_ID = "550e8400-e29b-41d4-a716-446655440000"
+TEST_CYCLE_ID = "550e8400-e29b-41d4-a716-446655440001"
+TEST_LOG_ID = "550e8400-e29b-41d4-a716-446655440002"
+TEST_LOG2_ID = "550e8400-e29b-41d4-a716-446655440003"
+
+SEED_SYMPTOMS = [
+    {"name": "Dolor abdominal (colicos)", "category": "fisica", "common_phase": "menstruacion"},
+    {"name": "Fatiga", "category": "fisica", "common_phase": "lutea"},
+    {"name": "Irritabilidad", "category": "emocional", "common_phase": "lutea"},
+    {"name": "Nauseas", "category": "digestiva", "common_phase": "menstruacion"},
+    {"name": "Sofocos", "category": "fisica", "common_phase": "todas"},
+]
+
+
+# ── Data fixtures (sync, no database) ───────────────────────
+
+@pytest.fixture
+def user_data():
+    return {
+        "id": TEST_USER_ID,
+        "email": "test@example.com",
+        "birth_date": date(1995, 6, 15),
+    }
+
+
+@pytest.fixture
+def cycle_data():
+    return {
+        "id": TEST_CYCLE_ID,
+        "user_id": TEST_USER_ID,
+        "start_date": date(2025, 6, 1),
+        "end_date": date(2025, 6, 5),
+    }
+
+
+@pytest.fixture
+def log_data():
+    return {
+        "id": TEST_LOG_ID,
+        "cycle_id": TEST_CYCLE_ID,
+        "date": date(2025, 6, 1),
+        "flow_level": "medium",
+        "temperature": 36.75,
+        "notes": "dia con colicos",
+    }
+
+
+@pytest.fixture
+def log2_data():
+    return {
+        "id": TEST_LOG2_ID,
+        "cycle_id": TEST_CYCLE_ID,
+        "date": date(2025, 6, 2),
+        "flow_level": "light",
+        "temperature": None,
+        "notes": None,
+    }
+
+
+@pytest.fixture
+def symptom_catalog_entries():
+    return SEED_SYMPTOMS
+
+
+@pytest.fixture
+def daily_symptom_entry():
+    return {
+        "log_id": TEST_LOG_ID,
+        "symptom_id": 1,
+        "intensity": 3,
+    }
+
+
+@pytest.fixture
+def log_with_symptoms():
+    return {
+        "id": TEST_LOG_ID,
+        "cycle_id": TEST_CYCLE_ID,
+        "date": date(2025, 6, 1),
+        "flow_level": "medium",
+        "temperature": 36.75,
+        "notes": "dia con colicos",
+        "symptoms": [
+            {"symptom_id": 1, "intensity": 3, "name": "Dolor abdominal (colicos)", "category": "fisica", "common_phase": "menstruacion"},
+            {"symptom_id": 2, "intensity": 2, "name": "Fatiga", "category": "fisica", "common_phase": "lutea"},
+        ],
+    }
+
+
+# ── Mock fixtures (unit tests, no database) ─────────────────
+
+class MockRow:
+    def __init__(self, data: dict):
+        self._mapping = data
+
+    def __getattr__(self, name):
+        return self._mapping.get(name)
+
+    def __getitem__(self, key):
+        return self._mapping[key]
+
+
+@pytest.fixture
+def mock_row(user_data):
+    return MockRow(user_data)
+
+
+@pytest.fixture
+def mock_conn():
+    conn = AsyncMock()
+    return conn
+
+
+@pytest.fixture
+def mock_engine(monkeypatch):
+    engine = AsyncMock()
+    conn = AsyncMock()
+    engine.connect.return_value.__aenter__.return_value = conn
+    engine.connect.return_value.__aexit__.return_value = None
+    monkeypatch.setattr("app.core.db.engine", engine)
+    return engine
+
+
+# ── Database fixtures (integration tests, requires DB) ──────
+
+def _get_test_db_url():
+    url = settings.TEST_DATABASE_URL or settings.DATABASE_URL
+    if url and url.startswith("postgresql://"):
+        url = url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    return url
+
+
+@pytest.fixture(scope="session")
+def test_db_url():
+    url = _get_test_db_url()
+    if not url:
+        pytest.skip("No TEST_DATABASE_URL or DATABASE_URL configured")
+    return url
+
+
+@pytest.fixture
+async def test_engine(test_db_url):
+    engine = create_async_engine(test_db_url, pool_pre_ping=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(metadata.create_all)
+    yield engine
+    async with engine.begin() as conn:
+        await conn.run_sync(metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest.fixture
+async def test_db(test_engine):
+    async with test_engine.connect() as conn:
+        yield conn
+
+
+@pytest.fixture
+async def seeded_db(test_db):
+    from sqlalchemy import insert
+    await test_db.execute(insert(symptoms_catalog_table).values(SEED_SYMPTOMS))
+    await test_db.commit()
+    yield test_db
+
+
+@pytest.fixture
+def auth_headers():
+    return {"Authorization": "Bearer test-token"}

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,144 @@
+from datetime import date
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.symptom import SymptomEntry, DailyLogCreate, DailyLogUpdate, SymptomResponse, SymptomLogEntry, DailyLogResponse, DailyLogListResponse
+from app.models.cycle import CycleCreate, CycleUpdate
+
+
+class TestCycleSchemas:
+
+    def test_create_valid(self):
+        c = CycleCreate(start_date=date(2025, 6, 1))
+        assert c.start_date == date(2025, 6, 1)
+        assert c.end_date is None
+
+    def test_create_with_end(self):
+        c = CycleCreate(start_date=date(2025, 6, 1), end_date=date(2025, 6, 5))
+        assert c.end_date == date(2025, 6, 5)
+
+    def test_create_invalid_dates(self):
+        with pytest.raises(ValidationError):
+            CycleCreate(start_date=date(2025, 6, 5), end_date=date(2025, 6, 1))
+
+    def test_update_partial(self):
+        c = CycleUpdate(start_date=date(2025, 6, 1))
+        assert c.start_date == date(2025, 6, 1)
+
+    def test_update_empty(self):
+        c = CycleUpdate()
+        assert c.start_date is None
+
+
+class TestSymptomSchemas:
+
+    def test_entry_valid(self):
+        s = SymptomEntry(symptom_id=1, intensity=3)
+        assert s.symptom_id == 1
+        assert s.intensity == 3
+
+    def test_entry_intensity_too_low(self):
+        with pytest.raises(ValidationError):
+            SymptomEntry(symptom_id=1, intensity=0)
+
+    def test_entry_intensity_too_high(self):
+        with pytest.raises(ValidationError):
+            SymptomEntry(symptom_id=1, intensity=6)
+
+    def test_response(self):
+        s = SymptomResponse(id=1, name="Fatiga", category="fisica", common_phase="lutea")
+        assert s.id == 1
+        assert s.common_phase == "lutea"
+
+    def test_response_nullable_phase(self):
+        s = SymptomResponse(id=1, name="Fatiga", category="fisica")
+        assert s.common_phase is None
+
+    def test_symptom_log_entry(self):
+        s = SymptomLogEntry(symptom_id=1, intensity=3, name="Fatiga", category="fisica", common_phase="lutea")
+        assert s.name == "Fatiga"
+
+
+class TestDailyLogSchemas:
+
+    def test_create_minimal(self):
+        d = DailyLogCreate(cycle_id="550e8400-e29b-41d4-a716-446655440001", date=date(2025, 6, 1))
+        assert d.symptoms == []
+
+    def test_create_with_symptoms(self):
+        d = DailyLogCreate(
+            cycle_id="550e8400-e29b-41d4-a716-446655440001",
+            date=date(2025, 6, 1),
+            flow_level="medium",
+            temperature=36.75,
+            symptoms=[{"symptom_id": 1, "intensity": 3}],
+        )
+        assert len(d.symptoms) == 1
+        assert d.flow_level == "medium"
+
+    def test_create_invalid_flow(self):
+        with pytest.raises(ValidationError):
+            DailyLogCreate(cycle_id="x", date=date(2025, 6, 1), flow_level="extreme")
+
+    def test_create_invalid_temperature(self):
+        with pytest.raises(ValidationError):
+            DailyLogCreate(cycle_id="x", date=date(2025, 6, 1), temperature=50.0)
+
+    def test_update_partial(self):
+        d = DailyLogUpdate(flow_level="light")
+        assert d.flow_level == "light"
+        assert d.symptoms is None
+
+    def test_update_with_symptoms(self):
+        d = DailyLogUpdate(symptoms=[{"symptom_id": 1, "intensity": 3}])
+        assert d.symptoms is not None
+
+    def test_update_empty_symptoms_clears_all(self):
+        d = DailyLogUpdate(symptoms=[])
+        assert d.symptoms == []
+
+    def test_response(self):
+        d = DailyLogResponse(
+            id="a", cycle_id="b", date=date(2025, 6, 1),
+            created_at="2025-06-01T00:00:00", updated_at="2025-06-01T00:00:00",
+        )
+        assert d.symptoms == []
+
+    def test_response_with_symptoms(self):
+        d = DailyLogResponse(
+            id="a", cycle_id="b", date=date(2025, 6, 1),
+            created_at="2025-06-01T00:00:00", updated_at="2025-06-01T00:00:00",
+            symptoms=[{"symptom_id": 1, "intensity": 3, "name": "Fatiga", "category": "fisica", "common_phase": None}],
+        )
+        assert len(d.symptoms) == 1
+
+    def test_list_response(self):
+        r = DailyLogListResponse(total=0, limit=50, offset=0, logs=[])
+        assert r.total == 0
+
+
+class TestDataFixtures:
+
+    def test_user_data(self, user_data):
+        assert user_data["id"].startswith("550e8400")
+        assert user_data["email"] == "test@example.com"
+
+    def test_cycle_data(self, cycle_data):
+        assert cycle_data["user_id"] == "550e8400-e29b-41d4-a716-446655440000"
+        assert cycle_data["start_date"] == date(2025, 6, 1)
+
+    def test_log_data(self, log_data):
+        assert log_data["flow_level"] == "medium"
+        assert log_data["temperature"] == 36.75
+
+    def test_log_with_symptoms(self, log_with_symptoms):
+        assert len(log_with_symptoms["symptoms"]) == 2
+        assert log_with_symptoms["symptoms"][0]["name"] == "Dolor abdominal (colicos)"
+
+    def test_symptom_catalog_entries(self, symptom_catalog_entries):
+        assert len(symptom_catalog_entries) == 5
+        categories = {s["category"] for s in symptom_catalog_entries}
+        assert "fisica" in categories
+        assert "emocional" in categories
+        assert "digestiva" in categories


### PR DESCRIPTION
## Sprint 3 — Issues completados

### #16 — Tablas symptoms_catalog + daily_symptoms (3NF)
- Migración Alembic `002_add_symptoms_seed.py` con los 30 síntomas del catálogo
- Repositorio `symptom_repo.py` con consultas para ambas tablas

### #17 — Endpoints CRUD /symptoms y /daily-logs
- `GET /symptoms` y `GET /symptoms/{id}` — catálogo de síntomas (público)
- `POST /daily-logs` — crear log con síntomas embebidos
- `GET /daily-logs?cycle_id=` — listar logs paginados
- `GET /daily-logs/{id}` — obtener log con síntomas
- `PUT /daily-logs/{id}` — actualizar log y reemplazar síntomas
- `DELETE /daily-logs/{id}` — eliminar log

### #20 — Fixtures de testing
- `conftest.py` con 14 fixtures (datos, mocks e integración)
- 27 tests unitarios para schemas Pydantic
- `TEST_DATABASE_URL` agregado a config

### Validaciones
- Ownership de ciclos verificada en cada operación
- Unicidad de fecha por ciclo
- Intensidad 1-5, flow_level validado, temperatura 35-42°C
- Ruff 0 errores, tests 27/27 pasados