### PR TITLE
Issue #18 y #19

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "@supabase/supabase-js": "^2.110.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "react-router-dom": "^7.18.1"
+        "react-router-dom": "^7.18.1",
+        "zustand": "^5.0.14"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -3806,7 +3807,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4780,7 +4781,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -10266,6 +10267,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "@supabase/supabase-js": "^2.110.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "react-router-dom": "^7.18.1"
+    "react-router-dom": "^7.18.1",
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import DemoPage from "./pages/DemoPage";
 import CalendarPage from "./pages/CalendarPage";
 import LoginPage from "./pages/LoginPage";
 import RegisterPage from "./pages/RegisterPage";
+import SymptomHistoryPage from "./pages/SymptomHistoryPage";
 
 function App() {
   return (
@@ -16,6 +17,14 @@ function App() {
           element={
             <PrivateRoute>
               <CalendarPage />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/history/:cycleId"
+          element={
+            <PrivateRoute>
+              <SymptomHistoryPage />
             </PrivateRoute>
           }
         />

--- a/frontend/src/components/calendar/Calendar.tsx
+++ b/frontend/src/components/calendar/Calendar.tsx
@@ -8,9 +8,16 @@ import { DayDetail } from "./DayDetail";
 interface CalendarProps {
   cycles: Cycle[];
   onEditCycle?: (cycleId: string) => void;
+  onRegisterDay?: (date: string, cycleId: string) => void;
+  onViewHistory?: (cycleId: string) => void;
 }
 
-export function Calendar({ cycles, onEditCycle }: CalendarProps) {
+export function Calendar({
+  cycles,
+  onEditCycle,
+  onRegisterDay,
+  onViewHistory,
+}: CalendarProps) {
   const today = new Date();
   const [currentDate, setCurrentDate] = useState(
     new Date(today.getFullYear(), today.getMonth(), 1),
@@ -84,6 +91,8 @@ export function Calendar({ cycles, onEditCycle }: CalendarProps) {
         day={selectedDay}
         onClose={() => setSelectedDay(null)}
         onEditCycle={onEditCycle}
+        onRegisterDay={onRegisterDay}
+        onViewHistory={onViewHistory}
       />
     </div>
   );

--- a/frontend/src/components/calendar/DayDetail.tsx
+++ b/frontend/src/components/calendar/DayDetail.tsx
@@ -8,25 +8,31 @@ interface DayDetailProps {
   day: CalendarDay | null;
   onClose: () => void;
   onEditCycle?: (cycleId: string) => void;
+  onRegisterDay?: (date: string, cycleId: string) => void;
+  onViewHistory?: (cycleId: string) => void;
 }
 
-function formatDate(date: Date): string {
-  return date.toLocaleDateString("es-ES", {
+export function DayDetail({
+  day,
+  onClose,
+  onEditCycle,
+  onRegisterDay,
+  onViewHistory,
+}: DayDetailProps) {
+  if (!day) return null;
+
+  const formattedDate = day.date.toLocaleDateString("es-ES", {
     weekday: "long",
     day: "numeric",
     month: "long",
   });
-}
-
-export function DayDetail({ day, onClose, onEditCycle }: DayDetailProps) {
-  if (!day) return null;
 
   return (
     <Card padding="md" className="mx-1 mt-3">
       <div className="flex items-start justify-between">
         <div>
           <h3 className="text-base font-semibold text-text-primary capitalize">
-            {formatDate(day.date)}
+            {formattedDate}
           </h3>
           {day.phase ? (
             <Badge variant={day.phase} className="mt-1">
@@ -109,15 +115,40 @@ export function DayDetail({ day, onClose, onEditCycle }: DayDetailProps) {
         </p>
       )}
 
-      {day.cycleId && onEditCycle && (
-        <div className="mt-4 pt-3 border-t border-border">
-          <Button
-            variant="ghost"
-            className="w-full text-sm"
-            onClick={() => onEditCycle(day.cycleId!)}
-          >
-            Editar este ciclo
-          </Button>
+      {day.cycleId && (
+        <div className="mt-4 pt-3 border-t border-border space-y-2">
+          {onRegisterDay && (
+            <Button
+              variant="primary"
+              className="w-full text-sm"
+              onClick={() =>
+                onRegisterDay(
+                  day.date.toISOString().split("T")[0],
+                  day.cycleId!,
+                )
+              }
+            >
+              {day.dailyLog ? "Editar registro del día" : "Registrar síntomas"}
+            </Button>
+          )}
+          {onViewHistory && (
+            <Button
+              variant="secondary"
+              className="w-full text-sm"
+              onClick={() => onViewHistory(day.cycleId!)}
+            >
+              Ver historial del ciclo
+            </Button>
+          )}
+          {onEditCycle && (
+            <Button
+              variant="ghost"
+              className="w-full text-sm"
+              onClick={() => onEditCycle(day.cycleId!)}
+            >
+              Editar este ciclo
+            </Button>
+          )}
         </div>
       )}
     </Card>

--- a/frontend/src/components/history/HistoryDay.tsx
+++ b/frontend/src/components/history/HistoryDay.tsx
@@ -1,0 +1,97 @@
+import type { DailyLog } from "../../lib/types";
+import { Card } from "../ui/Card";
+import { SymptomBar } from "./SymptomBar";
+
+interface HistoryDayProps {
+  log: DailyLog;
+}
+
+const FLOW_LABELS: Record<string, string> = {
+  none: "Sin flujo",
+  light: "Flujo leve",
+  medium: "Flujo medio",
+  heavy: "Flujo abundante",
+};
+
+const FLOW_DOT: Record<string, string> = {
+  none: "bg-gray-200",
+  light: "bg-red-200",
+  medium: "bg-red-400",
+  heavy: "bg-red-600",
+};
+
+const CATEGORY_ICONS: Record<string, string> = {
+  fisica: "💪",
+  emocional: "😔",
+  digestiva: "🌿",
+};
+
+const CATEGORY_TEXT_COLOR: Record<string, string> = {
+  fisica: "text-red-600",
+  emocional: "text-lavender-600",
+  digestiva: "text-green-600",
+};
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr + "T12:00:00").toLocaleDateString("es-ES", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+  });
+}
+
+export function HistoryDay({ log }: HistoryDayProps) {
+  return (
+    <Card padding="md">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold text-text-primary capitalize">
+          {formatDate(log.date)}
+        </h3>
+        <div className="flex items-center gap-1.5">
+          <span className={`h-2 w-2 rounded-full ${FLOW_DOT[log.flow_level]}`} />
+          <span className="text-xs text-text-muted">
+            {FLOW_LABELS[log.flow_level]}
+          </span>
+        </div>
+      </div>
+
+      {log.symptoms.length > 0 && (
+        <div className="space-y-2.5">
+          {log.symptoms.map((s) => (
+            <div key={s.symptom_id} className="flex items-center gap-2">
+              <span className="w-5 text-center text-xs">
+                {CATEGORY_ICONS[s.category]}
+              </span>
+              <span
+                className={`w-32 shrink-0 text-xs font-medium ${CATEGORY_TEXT_COLOR[s.category]}`}
+              >
+                {s.name}
+              </span>
+              <SymptomBar value={s.intensity} className="flex-1" />
+              <span className="w-4 text-center text-xs text-text-muted">
+                {s.intensity}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {log.temperature && (
+        <div className="mt-3 pt-3 border-t border-border">
+          <p className="text-xs text-text-muted">
+            Temperatura basal:{" "}
+            <span className="font-medium text-text-primary">
+              {log.temperature}°C
+            </span>
+          </p>
+        </div>
+      )}
+
+      {log.notes && (
+        <div className={`${log.symptoms.length > 0 || log.temperature ? "mt-3 pt-3 border-t border-border" : "mt-3"}`}>
+          <p className="text-xs text-text-muted italic">{log.notes}</p>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/components/history/SymptomBar.tsx
+++ b/frontend/src/components/history/SymptomBar.tsx
@@ -1,0 +1,22 @@
+interface SymptomBarProps {
+  value: number;
+  max?: number;
+  className?: string;
+}
+
+export function SymptomBar({ value, max = 5, className = "" }: SymptomBarProps) {
+  const segments = Array.from({ length: max }, (_, i) => i + 1);
+
+  return (
+    <div className={`flex gap-0.5 ${className}`} aria-label={`Intensidad ${value} de ${max}`}>
+      {segments.map((seg) => (
+        <span
+          key={seg}
+          className={`h-1.5 flex-1 rounded-full transition-colors ${
+            seg <= value ? "bg-eva-500" : "bg-gray-200"
+          }`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/history/SymptomHistory.tsx
+++ b/frontend/src/components/history/SymptomHistory.tsx
@@ -1,0 +1,147 @@
+import type { DailyLog, Cycle } from "../../lib/types";
+import { Card } from "../ui/Card";
+import { Badge } from "../ui/Badge";
+import { Button } from "../ui/Button";
+import { HistoryDay } from "./HistoryDay";
+
+interface SymptomHistoryProps {
+  cycle: Cycle | null;
+  logs: DailyLog[];
+  loading: boolean;
+  error: string | null;
+  onPrevCycle: () => void;
+  onNextCycle: () => void;
+  hasPrev: boolean;
+  hasNext: boolean;
+  onRegisterDay: () => void;
+  onBack: () => void;
+}
+
+export function SymptomHistory({
+  cycle,
+  logs,
+  loading,
+  error,
+  onPrevCycle,
+  onNextCycle,
+  hasPrev,
+  hasNext,
+  onRegisterDay,
+  onBack,
+}: SymptomHistoryProps) {
+  return (
+    <div>
+      <div className="mb-6">
+        <button
+          type="button"
+          onClick={onBack}
+          className="mb-3 flex items-center gap-1 text-sm text-eva-600 hover:text-eva-700 transition-colors"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M15 18l-6-6 6-6" />
+          </svg>
+          Volver al calendario
+        </button>
+        <h1 className="text-2xl font-bold text-text-primary">
+          Historial de síntomas
+        </h1>
+      </div>
+
+      {cycle && (
+        <Card padding="md" className="mb-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-xs text-text-muted uppercase tracking-wide">
+                Ciclo
+              </p>
+              <p className="text-sm font-medium text-text-primary">
+                {new Date(cycle.start_date + "T12:00:00").toLocaleDateString(
+                  "es-ES",
+                  { day: "numeric", month: "long", year: "numeric" },
+                )}
+                {cycle.end_date && (
+                  <>
+                    {" — "}
+                    {new Date(cycle.end_date + "T12:00:00").toLocaleDateString(
+                      "es-ES",
+                      { day: "numeric", month: "long" },
+                    )}
+                  </>
+                )}
+              </p>
+            </div>
+            {cycle.duration_days > 0 && (
+              <Badge variant="default">{cycle.duration_days} días</Badge>
+            )}
+          </div>
+
+          <div className="mt-4 flex gap-2">
+            <Button
+              variant="ghost"
+              onClick={onPrevCycle}
+              disabled={!hasPrev}
+              className="flex-1 text-sm"
+            >
+              ← Anterior
+            </Button>
+            <Button
+              variant="ghost"
+              onClick={onNextCycle}
+              disabled={!hasNext}
+              className="flex-1 text-sm"
+            >
+              Siguiente →
+            </Button>
+          </div>
+        </Card>
+      )}
+
+      {error && (
+        <Card padding="md" className="mb-4 border-red-200 bg-red-50">
+          <p className="text-sm text-red-600">{error}</p>
+        </Card>
+      )}
+
+      {loading ? (
+        <Card padding="lg">
+          <div className="flex items-center justify-center py-12">
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-eva-300 border-t-eva-600" />
+          </div>
+        </Card>
+      ) : logs.length === 0 ? (
+        <Card padding="lg" className="text-center">
+          <p className="text-3xl mb-3">📋</p>
+          <p className="text-sm font-medium text-text-primary">
+            Sin registros en este ciclo
+          </p>
+          <p className="mt-1 text-xs text-text-muted">
+            Registra tus síntomas cada día para ver tu historial aquí.
+          </p>
+          <Button
+            variant="primary"
+            className="mt-4 text-sm"
+            onClick={onRegisterDay}
+          >
+            Registrar primer día
+          </Button>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {logs.map((log) => (
+            <HistoryDay key={log.id} log={log} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/symptoms/DailyLogForm.tsx
+++ b/frontend/src/components/symptoms/DailyLogForm.tsx
@@ -1,0 +1,175 @@
+import { useEffect } from "react";
+import type { DailyLog } from "../../lib/types";
+import { useDailyLogForm } from "../../hooks/useDailyLogForm";
+import { useSymptomStore } from "../../store/symptomStore";
+import { Card } from "../ui/Card";
+import { Button } from "../ui/Button";
+import { Toast } from "../ui/Toast";
+import { SymptomGrid } from "./SymptomGrid";
+import { IntensitySlider } from "./IntensitySlider";
+import { FlowSelector } from "./FlowSelector";
+import { TemperatureInput } from "./TemperatureInput";
+
+interface DailyLogFormProps {
+  cycleId: string;
+  date: string;
+  initialData?: DailyLog | null;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+function formatDateDisplay(dateStr: string): string {
+  return new Date(dateStr + "T12:00:00").toLocaleDateString("es-ES", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  });
+}
+
+export function DailyLogForm({
+  cycleId,
+  date,
+  initialData,
+  onSuccess,
+  onCancel,
+}: DailyLogFormProps) {
+  const { symptoms: catalog, isLoaded, loadSymptoms } = useSymptomStore();
+  const isEditing = Boolean(initialData);
+
+  useEffect(() => {
+    loadSymptoms();
+  }, [loadSymptoms]);
+
+  const {
+    selectedSymptoms,
+    flowLevel,
+    temperature,
+    notes,
+    error,
+    submitting,
+    successMessage,
+    toggleSymptom,
+    setIntensity,
+    setFlowLevel,
+    setTemperature,
+    setNotes,
+    handleSubmit,
+    dismissSuccess,
+  } = useDailyLogForm({ cycleId, date, initialData: initialData ?? null, onSuccess });
+
+  const selectedIds = new Set(selectedSymptoms.keys());
+
+  return (
+    <Card padding="md" className="mx-1 mt-3">
+      <h3 className="mb-1 text-base font-semibold text-text-primary capitalize">
+        {isEditing ? "Editar registro" : "Registrar día"}
+      </h3>
+      <p className="mb-4 text-sm text-text-muted capitalize">
+        {formatDateDisplay(date)}
+      </p>
+
+      <div className="flex flex-col gap-5">
+        <div>
+          <p className="mb-2 text-sm font-medium text-text-secondary">
+            Síntomas
+          </p>
+          {!isLoaded ? (
+            <div className="flex items-center justify-center py-6">
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-eva-300 border-t-eva-600" />
+            </div>
+          ) : (
+            <SymptomGrid
+              symptoms={catalog}
+              selectedIds={selectedIds}
+              onToggle={toggleSymptom}
+            />
+          )}
+
+          {selectedSymptoms.size > 0 && (
+            <div className="mt-4 space-y-3">
+              {Array.from(selectedSymptoms.values()).map((s) => (
+                <div key={s.symptom_id} className="flex items-center gap-3">
+                  <span className="w-28 shrink-0 text-xs text-text-secondary">
+                    {s.name}
+                  </span>
+                  <div className="flex-1">
+                    <IntensitySlider
+                      value={s.intensity}
+                      onChange={(v) => setIntensity(s.symptom_id, v)}
+                    />
+                  </div>
+                  <span className="w-5 text-center text-xs font-medium text-text-muted">
+                    {s.intensity}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div>
+          <p className="mb-2 text-sm font-medium text-text-secondary">
+            Nivel de flujo
+          </p>
+          <FlowSelector value={flowLevel} onChange={setFlowLevel} />
+        </div>
+
+        <div className="flex gap-4">
+          <div className="w-1/2">
+            <TemperatureInput
+              value={temperature}
+              onChange={setTemperature}
+            />
+          </div>
+          <div className="w-1/2 flex flex-col gap-1.5">
+            <label className="text-sm font-medium text-text-primary">
+              Notas
+            </label>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="¿Cómo te sentiste hoy?"
+              rows={2}
+              className="rounded-lg border border-border px-4 py-2.5 text-sm text-text-primary placeholder:text-text-muted transition-colors focus:border-border-focus focus:outline-none focus:ring-2 focus:ring-eva-400/30 resize-none"
+            />
+          </div>
+        </div>
+
+        {error && (
+          <p className="text-sm text-red-500" role="alert">
+            {error}
+          </p>
+        )}
+
+        <div className="flex gap-3">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={onCancel}
+            disabled={submitting}
+          >
+            Cancelar
+          </Button>
+          <Button type="button" onClick={handleSubmit} disabled={submitting}>
+            {submitting ? (
+              <span className="flex items-center gap-2">
+                <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                Guardando...
+              </span>
+            ) : (
+              "Guardar registro"
+            )}
+          </Button>
+        </div>
+      </div>
+
+      {successMessage && (
+        <Toast
+          message={successMessage}
+          variant="success"
+          onDismiss={dismissSuccess}
+        />
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/components/symptoms/FlowSelector.tsx
+++ b/frontend/src/components/symptoms/FlowSelector.tsx
@@ -1,0 +1,57 @@
+interface FlowSelectorProps {
+  value: string;
+  onChange: (v: string) => void;
+}
+
+const FLOW_OPTIONS = [
+  {
+    value: "none",
+    label: "Ninguno",
+    dot: "bg-gray-200",
+    activeDot: "bg-gray-400",
+  },
+  {
+    value: "light",
+    label: "Leve",
+    dot: "bg-red-200",
+    activeDot: "bg-red-400",
+  },
+  {
+    value: "medium",
+    label: "Medio",
+    dot: "bg-red-300",
+    activeDot: "bg-red-500",
+  },
+  {
+    value: "heavy",
+    label: "Abundante",
+    dot: "bg-red-400",
+    activeDot: "bg-red-600",
+  },
+];
+
+export function FlowSelector({ value, onChange }: FlowSelectorProps) {
+  return (
+    <div className="flex gap-2">
+      {FLOW_OPTIONS.map((opt) => (
+        <button
+          key={opt.value}
+          type="button"
+          onClick={() => onChange(opt.value)}
+          className={`flex flex-1 flex-col items-center gap-1.5 rounded-lg border px-2 py-2.5 text-xs font-medium transition-colors ${
+            value === opt.value
+              ? "border-eva-400 bg-eva-50 text-eva-700"
+              : "border-border bg-white text-text-muted hover:bg-surface-alt"
+          }`}
+        >
+          <span
+            className={`h-2.5 w-2.5 rounded-full ${
+              value === opt.value ? opt.activeDot : opt.dot
+            }`}
+          />
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/symptoms/IntensitySlider.tsx
+++ b/frontend/src/components/symptoms/IntensitySlider.tsx
@@ -1,0 +1,30 @@
+interface IntensitySliderProps {
+  value: number;
+  onChange: (value: number) => void;
+}
+
+const INTENSITY_LABELS = ["Muy leve", "Leve", "Moderado", "Intenso", "Muy intenso"];
+
+export function IntensitySlider({ value, onChange }: IntensitySliderProps) {
+  const segments = [1, 2, 3, 4, 5];
+
+  return (
+    <div className="flex items-center gap-0.5" role="radiogroup" aria-label="Intensidad">
+      {segments.map((seg) => (
+        <button
+          key={seg}
+          type="button"
+          role="radio"
+          aria-checked={value === seg}
+          aria-label={INTENSITY_LABELS[seg - 1]}
+          onClick={() => onChange(seg)}
+          className={`h-6 flex-1 rounded transition-colors ${
+            seg <= value
+              ? "bg-eva-500"
+              : "bg-gray-200 hover:bg-gray-300"
+          }`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/symptoms/SymptomGrid.tsx
+++ b/frontend/src/components/symptoms/SymptomGrid.tsx
@@ -1,0 +1,67 @@
+import type { SymptomCatalogItem } from "../../services/symptomService";
+
+interface SymptomGridProps {
+  symptoms: SymptomCatalogItem[];
+  selectedIds: Set<number>;
+  onToggle: (s: SymptomCatalogItem) => void;
+}
+
+const CATEGORY_META: Record<
+  string,
+  { label: string; icon: string; color: string }
+> = {
+  fisica: {
+    label: "Física",
+    icon: "💪",
+    color: "border-red-200 bg-red-50 text-red-700 hover:bg-red-100 data-[selected=true]:bg-red-200 data-[selected=true]:border-red-400",
+  },
+  emocional: {
+    label: "Emocional",
+    icon: "😔",
+    color: "border-lavender-200 bg-lavender-50 text-lavender-700 hover:bg-lavender-100 data-[selected=true]:bg-lavender-200 data-[selected=true]:border-lavender-400",
+  },
+  digestiva: {
+    label: "Digestiva",
+    icon: "🌿",
+    color: "border-green-200 bg-green-50 text-green-700 hover:bg-green-100 data-[selected=true]:bg-green-200 data-[selected=true]:border-green-400",
+  },
+};
+
+export function SymptomGrid({
+  symptoms,
+  selectedIds,
+  onToggle,
+}: SymptomGridProps) {
+  const categories = ["fisica", "emocional", "digestiva"] as const;
+
+  return (
+    <div className="space-y-4">
+      {categories.map((cat) => {
+        const meta = CATEGORY_META[cat];
+        const catSymptoms = symptoms.filter((s) => s.category === cat);
+        if (catSymptoms.length === 0) return null;
+
+        return (
+          <div key={cat}>
+            <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-muted">
+              {meta.icon} {meta.label}
+            </h4>
+            <div className="flex flex-wrap gap-1.5">
+              {catSymptoms.map((symptom) => (
+                <button
+                  key={symptom.id}
+                  type="button"
+                  data-selected={selectedIds.has(symptom.id)}
+                  onClick={() => onToggle(symptom)}
+                  className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${meta.color}`}
+                >
+                  {symptom.name}
+                </button>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/symptoms/TemperatureInput.tsx
+++ b/frontend/src/components/symptoms/TemperatureInput.tsx
@@ -1,0 +1,26 @@
+import { Input } from "../ui/Input";
+
+interface TemperatureInputProps {
+  value: string;
+  onChange: (v: string) => void;
+}
+
+export function TemperatureInput({ value, onChange }: TemperatureInputProps) {
+  const numValue = value ? parseFloat(value) : null;
+  const hasError =
+    value !== "" && (numValue === null || isNaN(numValue) || numValue < 35 || numValue > 42);
+
+  return (
+    <Input
+      label="Temperatura basal"
+      type="number"
+      min={35}
+      max={42}
+      step={0.1}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder="36.5"
+      error={hasError ? "Debe estar entre 35°C y 42°C" : undefined}
+    />
+  );
+}

--- a/frontend/src/hooks/useDailyLogForm.ts
+++ b/frontend/src/hooks/useDailyLogForm.ts
@@ -1,0 +1,175 @@
+import { useState, useCallback } from "react";
+import type { DailyLog, DailySymptom } from "../lib/types";
+import { createDailyLog, updateDailyLog } from "../services/dailyLogService";
+
+interface UseDailyLogFormOptions {
+  cycleId: string;
+  date: string;
+  initialData?: DailyLog | null;
+  onSuccess: () => void;
+}
+
+interface SelectedSymptom {
+  symptom_id: number;
+  name: string;
+  category: string;
+  intensity: number;
+}
+
+interface UseDailyLogFormReturn {
+  selectedSymptoms: Map<number, SelectedSymptom>;
+  flowLevel: string;
+  temperature: string;
+  notes: string;
+  error: string | null;
+  submitting: boolean;
+  successMessage: string | null;
+  toggleSymptom: (symptom: { id: number; name: string; category: string }) => void;
+  setIntensity: (symptomId: number, intensity: number) => void;
+  setFlowLevel: (v: string) => void;
+  setTemperature: (v: string) => void;
+  setNotes: (v: string) => void;
+  handleSubmit: () => Promise<void>;
+  dismissSuccess: () => void;
+}
+
+function buildInitialSymptoms(data: DailyLog | null | undefined): Map<number, SelectedSymptom> {
+  if (!data) return new Map();
+  const map = new Map<number, SelectedSymptom>();
+  data.symptoms.forEach((s) =>
+    map.set(s.symptom_id, {
+      symptom_id: s.symptom_id,
+      name: s.name,
+      category: s.category,
+      intensity: s.intensity,
+    }),
+  );
+  return map;
+}
+
+export function useDailyLogForm({
+  cycleId,
+  date,
+  initialData,
+  onSuccess,
+}: UseDailyLogFormOptions): UseDailyLogFormReturn {
+  const [selectedSymptoms, setSelectedSymptoms] = useState<
+    Map<number, SelectedSymptom>
+  >(() => buildInitialSymptoms(initialData));
+  const [flowLevel, setFlowLevel] = useState<string>(
+    initialData?.flow_level ?? "none",
+  );
+  const [temperature, setTemperature] = useState(
+    initialData?.temperature?.toString() ?? "",
+  );
+  const [notes, setNotes] = useState(initialData?.notes ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const toggleSymptom = useCallback(
+    (symptom: { id: number; name: string; category: string }) => {
+      setSelectedSymptoms((prev) => {
+        const next = new Map(prev);
+        if (next.has(symptom.id)) {
+          next.delete(symptom.id);
+        } else {
+          next.set(symptom.id, {
+            symptom_id: symptom.id,
+            name: symptom.name,
+            category: symptom.category,
+            intensity: 3,
+          });
+        }
+        return next;
+      });
+      setError(null);
+    },
+    [],
+  );
+
+  const setIntensity = useCallback((symptomId: number, intensity: number) => {
+    setSelectedSymptoms((prev) => {
+      const next = new Map(prev);
+      const existing = next.get(symptomId);
+      if (existing) {
+        next.set(symptomId, { ...existing, intensity });
+      }
+      return next;
+    });
+  }, []);
+
+  const handleSubmit = useCallback(async () => {
+    const symptomsArray: DailySymptom[] = Array.from(
+      selectedSymptoms.values(),
+    ).map((s) => ({
+      symptom_id: s.symptom_id,
+      name: s.name,
+      category: s.category,
+      intensity: s.intensity,
+    }));
+
+    const tempValue = temperature ? parseFloat(temperature) : null;
+
+    if (
+      temperature &&
+      (isNaN(tempValue!) || tempValue! < 35 || tempValue! > 42)
+    ) {
+      setError("La temperatura debe estar entre 35°C y 42°C");
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+    setSuccessMessage(null);
+
+    try {
+      if (initialData) {
+        await updateDailyLog(initialData.id, cycleId, {
+          flow_level: flowLevel,
+          temperature: tempValue,
+          notes: notes || null,
+          symptoms: symptomsArray,
+        });
+        setSuccessMessage("Registro actualizado correctamente");
+      } else {
+        await createDailyLog({
+          cycle_id: cycleId,
+          date,
+          flow_level: flowLevel,
+          temperature: tempValue,
+          notes: notes || null,
+          symptoms: symptomsArray,
+        });
+        setSuccessMessage("Registro guardado correctamente");
+      }
+
+      setTimeout(onSuccess, 800);
+    } catch {
+      setError("Ocurrió un error al guardar. Intenta de nuevo.");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [selectedSymptoms, flowLevel, temperature, notes, cycleId, date, initialData, onSuccess]);
+
+  const dismissSuccess = useCallback(() => {
+    setSuccessMessage(null);
+  }, []);
+
+  return {
+    selectedSymptoms,
+    flowLevel,
+    temperature,
+    notes,
+    error,
+    submitting,
+    successMessage,
+    toggleSymptom,
+    setIntensity,
+    setFlowLevel,
+    setTemperature,
+    setNotes,
+    handleSubmit,
+    dismissSuccess,
+  };
+}

--- a/frontend/src/hooks/useDailyLogs.ts
+++ b/frontend/src/hooks/useDailyLogs.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect, useCallback } from "react";
+import type { DailyLog } from "../lib/types";
+import { getDailyLogsByCycle } from "../services/dailyLogService";
+
+interface UseDailyLogsReturn {
+  logs: DailyLog[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+export function useDailyLogs(cycleId: string): UseDailyLogsReturn {
+  const [logs, setLogs] = useState<DailyLog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await getDailyLogsByCycle(cycleId);
+        if (!cancelled) {
+          setLogs(data);
+        }
+      } catch {
+        if (!cancelled) {
+          setError("No se pudieron cargar los registros");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [cycleId]);
+
+  const refetch = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getDailyLogsByCycle(cycleId);
+      setLogs(data);
+    } catch {
+      setError("No se pudieron cargar los registros");
+    } finally {
+      setLoading(false);
+    }
+  }, [cycleId]);
+
+  return { logs, loading, error, refetch };
+}

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,14 +1,23 @@
 import { useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 import { useCycles } from "../hooks/useCycles";
+import type { DailyLog } from "../lib/types";
+import { getDailyLogsByCycle } from "../services/dailyLogService";
 import { Card } from "../components/ui/Card";
 import { Button } from "../components/ui/Button";
 import { Calendar } from "../components/calendar/Calendar";
 import { CycleForm } from "../components/cycle/CycleForm";
+import { DailyLogForm } from "../components/symptoms/DailyLogForm";
 
 export default function CalendarPage() {
+  const navigate = useNavigate();
   const { cycles, loading, error, refetch } = useCycles();
   const [showForm, setShowForm] = useState(false);
   const [editingCycleId, setEditingCycleId] = useState<string | null>(null);
+  const [showLogForm, setShowLogForm] = useState(false);
+  const [logDate, setLogDate] = useState<string>("");
+  const [logCycleId, setLogCycleId] = useState<string>("");
+  const [editingLog, setEditingLog] = useState<DailyLog | null>(null);
 
   const editingCycle = editingCycleId
     ? cycles.find((c) => c.id === editingCycleId)
@@ -24,16 +33,65 @@ export default function CalendarPage() {
     setShowForm(true);
   }, []);
 
-  const handleFormSuccess = useCallback(() => {
+  const handleRegisterDay = useCallback(
+    async (date: string, cycleId: string) => {
+      const logs = await getDailyLogsByCycle(cycleId);
+      const existing = logs.find((l: DailyLog) => l.date === date) ?? null;
+      setEditingLog(existing);
+      setLogDate(date);
+      setLogCycleId(cycleId);
+      setShowLogForm(true);
+    },
+    [],
+  );
+
+  const handleViewHistory = useCallback(
+    (cycleId: string) => {
+      navigate(`/history/${cycleId}`);
+    },
+    [navigate],
+  );
+
+  const handleCycleFormSuccess = useCallback(() => {
     setShowForm(false);
     setEditingCycleId(null);
     refetch();
   }, [refetch]);
 
-  const handleFormCancel = useCallback(() => {
+  const handleCycleFormCancel = useCallback(() => {
     setShowForm(false);
     setEditingCycleId(null);
   }, []);
+
+  const handleLogFormSuccess = useCallback(() => {
+    setShowLogForm(false);
+    setEditingLog(null);
+    refetch();
+  }, [refetch]);
+
+  const handleLogFormCancel = useCallback(() => {
+    setShowLogForm(false);
+    setEditingLog(null);
+  }, []);
+
+  if (showLogForm) {
+    return (
+      <div className="mx-auto max-w-lg px-4 py-6">
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-text-primary">
+            Mi Calendario
+          </h1>
+        </div>
+        <DailyLogForm
+          cycleId={logCycleId}
+          date={logDate}
+          initialData={editingLog}
+          onSuccess={handleLogFormSuccess}
+          onCancel={handleLogFormCancel}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="mx-auto max-w-lg px-4 py-6">
@@ -76,12 +134,17 @@ export default function CalendarPage() {
                 }
               : undefined
           }
-          onSuccess={handleFormSuccess}
-          onCancel={handleFormCancel}
+          onSuccess={handleCycleFormSuccess}
+          onCancel={handleCycleFormCancel}
         />
       ) : (
         <Card padding="sm">
-          <Calendar cycles={cycles} onEditCycle={handleEditCycle} />
+          <Calendar
+            cycles={cycles}
+            onEditCycle={handleEditCycle}
+            onRegisterDay={handleRegisterDay}
+            onViewHistory={handleViewHistory}
+          />
         </Card>
       )}
     </div>

--- a/frontend/src/pages/SymptomHistoryPage.tsx
+++ b/frontend/src/pages/SymptomHistoryPage.tsx
@@ -1,0 +1,61 @@
+import { useMemo } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { useCycles } from "../hooks/useCycles";
+import { useDailyLogs } from "../hooks/useDailyLogs";
+import { SymptomHistory } from "../components/history/SymptomHistory";
+
+export default function SymptomHistoryPage() {
+  const { cycleId } = useParams<{ cycleId: string }>();
+  const navigate = useNavigate();
+  const { cycles, loading: cyclesLoading } = useCycles();
+  const { logs, loading: logsLoading, error: logsError } = useDailyLogs(cycleId ?? "");
+
+  const sortedCycles = useMemo(() => {
+    return [...cycles].sort(
+      (a, b) =>
+        new Date(b.start_date).getTime() - new Date(a.start_date).getTime(),
+    );
+  }, [cycles]);
+
+  const currentIndex = sortedCycles.findIndex((c) => c.id === cycleId);
+  const cycle = currentIndex !== -1 ? sortedCycles[currentIndex] : null;
+  const hasPrev = currentIndex < sortedCycles.length - 1;
+  const hasNext = currentIndex > 0;
+
+  const handlePrevCycle = () => {
+    if (hasPrev) {
+      navigate(`/history/${sortedCycles[currentIndex + 1].id}`);
+    }
+  };
+
+  const handleNextCycle = () => {
+    if (hasNext) {
+      navigate(`/history/${sortedCycles[currentIndex - 1].id}`);
+    }
+  };
+
+  const handleRegisterDay = () => {
+    navigate(`/calendar`);
+  };
+
+  const handleBack = () => {
+    navigate("/calendar");
+  };
+
+  return (
+    <div className="mx-auto max-w-lg px-4 py-6">
+      <SymptomHistory
+        cycle={cycle}
+        logs={logs}
+        loading={cyclesLoading || logsLoading}
+        error={logsError}
+        onPrevCycle={handlePrevCycle}
+        onNextCycle={handleNextCycle}
+        hasPrev={hasPrev}
+        hasNext={hasNext}
+        onRegisterDay={handleRegisterDay}
+        onBack={handleBack}
+      />
+    </div>
+  );
+}

--- a/frontend/src/services/dailyLogService.ts
+++ b/frontend/src/services/dailyLogService.ts
@@ -1,0 +1,94 @@
+import type { DailyLog } from "../lib/types";
+
+const MOCK_LOGS: Map<string, DailyLog[]> = new Map();
+
+const MOCK_CYCLE_LOGS: DailyLog[] = [
+  {
+    id: "log-001",
+    date: "2026-06-27",
+    flow_level: "heavy",
+    temperature: 36.5,
+    notes: "Primer día, dolor intenso por la mañana",
+    symptoms: [
+      { symptom_id: 1, name: "Dolor abdominal", category: "fisica", intensity: 4 },
+      { symptom_id: 3, name: "Fatiga", category: "fisica", intensity: 3 },
+      { symptom_id: 6, name: "Irritabilidad", category: "emocional", intensity: 2 },
+    ],
+  },
+  {
+    id: "log-002",
+    date: "2026-06-28",
+    flow_level: "medium",
+    temperature: 36.7,
+    notes: null,
+    symptoms: [
+      { symptom_id: 1, name: "Dolor abdominal", category: "fisica", intensity: 3 },
+      { symptom_id: 11, name: "Sensibilidad mamaria", category: "fisica", intensity: 2 },
+    ],
+  },
+  {
+    id: "log-003",
+    date: "2026-06-29",
+    flow_level: "light",
+    temperature: 36.6,
+    notes: "Mejorando",
+    symptoms: [
+      { symptom_id: 3, name: "Fatiga", category: "fisica", intensity: 2 },
+    ],
+  },
+];
+
+MOCK_LOGS.set("c3-5e7a-4b1d-9f3c-8a2e1d4b6f00", [...MOCK_CYCLE_LOGS]);
+
+export async function getDailyLogsByCycle(
+  cycleId: string,
+): Promise<DailyLog[]> {
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  return MOCK_LOGS.get(cycleId) ?? [];
+}
+
+export async function createDailyLog(data: {
+  cycle_id: string;
+  date: string;
+  flow_level: string;
+  temperature: number | null;
+  notes: string | null;
+  symptoms: Array<{ symptom_id: number; name: string; category: string; intensity: number }>;
+}): Promise<DailyLog> {
+  await new Promise((resolve) => setTimeout(resolve, 300));
+
+  const newLog: DailyLog = {
+    id: `log-${Date.now()}`,
+    date: data.date,
+    flow_level: data.flow_level as DailyLog["flow_level"],
+    temperature: data.temperature,
+    notes: data.notes,
+    symptoms: data.symptoms,
+  };
+
+  const logs = MOCK_LOGS.get(data.cycle_id) ?? [];
+  logs.push(newLog);
+  MOCK_LOGS.set(data.cycle_id, logs);
+
+  return newLog;
+}
+
+export async function updateDailyLog(
+  logId: string,
+  cycleId: string,
+  data: {
+    flow_level?: string;
+    temperature?: number | null;
+    notes?: string | null;
+    symptoms?: Array<{ symptom_id: number; name: string; category: string; intensity: number }>;
+  },
+): Promise<DailyLog> {
+  await new Promise((resolve) => setTimeout(resolve, 300));
+
+  const logs = MOCK_LOGS.get(cycleId) ?? [];
+  const idx = logs.findIndex((l) => l.id === logId);
+  if (idx === -1) throw new Error("Daily log not found");
+
+  logs[idx] = { ...logs[idx], ...data } as DailyLog;
+  return logs[idx];
+}

--- a/frontend/src/services/symptomService.ts
+++ b/frontend/src/services/symptomService.ts
@@ -1,0 +1,28 @@
+export interface SymptomCatalogItem {
+  id: number;
+  name: string;
+  category: "fisica" | "emocional" | "digestiva";
+}
+
+const MOCK_SYMPTOMS: SymptomCatalogItem[] = [
+  { id: 1, name: "Dolor abdominal", category: "fisica" },
+  { id: 2, name: "Dolor de cabeza", category: "fisica" },
+  { id: 3, name: "Fatiga", category: "fisica" },
+  { id: 4, name: "Hinchazón", category: "digestiva" },
+  { id: 5, name: "Náuseas", category: "digestiva" },
+  { id: 6, name: "Irritabilidad", category: "emocional" },
+  { id: 7, name: "Ansiedad", category: "emocional" },
+  { id: 8, name: "Tristeza", category: "emocional" },
+  { id: 9, name: "Antojos", category: "digestiva" },
+  { id: 10, name: "Acné", category: "fisica" },
+  { id: 11, name: "Sensibilidad mamaria", category: "fisica" },
+  { id: 12, name: "Insomnio", category: "fisica" },
+  { id: 13, name: "Energía alta", category: "fisica" },
+  { id: 14, name: "Dolor lumbar", category: "fisica" },
+  { id: 15, name: "Problemas de concentración", category: "emocional" },
+];
+
+export async function getSymptomCatalog(): Promise<SymptomCatalogItem[]> {
+  await new Promise((resolve) => setTimeout(resolve, 150));
+  return MOCK_SYMPTOMS;
+}

--- a/frontend/src/store/symptomStore.ts
+++ b/frontend/src/store/symptomStore.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+import type { SymptomCatalogItem } from "../services/symptomService";
+import { getSymptomCatalog } from "../services/symptomService";
+
+interface SymptomStore {
+  symptoms: SymptomCatalogItem[];
+  isLoaded: boolean;
+  isLoading: boolean;
+  loadSymptoms: () => Promise<void>;
+}
+
+export const useSymptomStore = create<SymptomStore>((set, get) => ({
+  symptoms: [],
+  isLoaded: false,
+  isLoading: false,
+
+  loadSymptoms: async () => {
+    if (get().isLoaded || get().isLoading) return;
+    set({ isLoading: true });
+    try {
+      const data = await getSymptomCatalog();
+      set({ symptoms: data, isLoaded: true, isLoading: false });
+    } catch {
+      set({ isLoading: false });
+    }
+  },
+}));


### PR DESCRIPTION
### Issue #18 — [S3] Formulario de registro diario de síntomas
**Asignado:** Daniel | **Labels:** `frontend`

```
## Descripción
Interfaz para que la usuaria registre cómo se siente cada día del ciclo.

## Criterios de aceptación
- [ ] Grid de síntomas organizados por categoría (física, emocional, digestiva)
- [ ] Al seleccionar un síntoma, aparece un slider de intensidad del 1 al 5
- [ ] Selector de nivel de flujo con 4 opciones visuales: ninguno / leve / medio / abundante
- [ ] Campo de temperatura basal (opcional, input numérico con validación 35–42°C)
- [ ] Área de notas libres (textarea)
- [ ] Botón de guardar conectado a `POST /daily-logs`
- [ ] Si ya existe un registro del día, carga los datos y usa `PUT /daily-logs/{id}`
- [ ] Estado de carga y feedback de éxito/error

## Notas técnicas
Los síntomas disponibles se obtienen de `GET /symptoms/catalog` al cargar el componente.
Cachear en Zustand store para no re-fetch en cada apertura del formulario.
```

---

### Issue #19 — [S3] Vista historial de síntomas por ciclo
**Asignado:** Daniel | **Labels:** `frontend`

```
## Descripción
Pantalla que muestra el historial de síntomas de un ciclo completo en forma visual.

## Criterios de aceptación
- [ ] Lista de días con síntomas registrados, ordenada cronológicamente
- [ ] Iconos o badges por categoría de síntoma (💪 física, 😔 emocional, 🌿 digestiva)
- [ ] Barra visual de intensidad (1–5) para cada síntoma
- [ ] Indicador del nivel de flujo por día (color según intensidad)
- [ ] Temperatura basal mostrada si fue registrada
- [ ] Navegación entre ciclos (anterior / siguiente)
- [ ] Estado vacío cuando no hay registros en el ciclo

## Notas técnicas
Conectado a `GET /daily-logs/{cycle_id}`. Si el ciclo no tiene logs,
mostrar ilustración de estado vacío con CTA para registrar.
```