### PR TITLE
Merge develop into mades2

### DIFF
--- a/backend/app/services/cycle_service.py
+++ b/backend/app/services/cycle_service.py
@@ -14,7 +14,7 @@ def _calc_duration(start: date, end: Optional[date]) -> Optional[int]:
 
 
 def _row_to_dict(row, duration: Optional[int] = None) -> dict:
-    data = dict(row._mapping)
+    data = row if isinstance(row, dict) else dict(row._mapping)
     data["duration_days"] = duration or _calc_duration(data["start_date"], data.get("end_date"))
     data["id"] = str(data["id"])
     data["user_id"] = str(data["user_id"])
@@ -86,7 +86,7 @@ async def delete_cycle(cycle_id: str, user_id: str) -> None:
 
 
 def _log_row_to_dict(row) -> dict:
-    data = dict(row._mapping)
+    data = row if isinstance(row, dict) else dict(row._mapping)
     data["id"] = str(data["id"])
     data["date"] = data["date"].isoformat() if isinstance(data.get("date"), date) else data.get("date")
     data["temperature"] = float(data["temperature"]) if data.get("temperature") else None

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 asyncio_default_fixture_loop_scope = function
+asyncio_mode = auto
 testpaths = tests

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -9,3 +9,6 @@ pytest==8.3.5
 pytest-asyncio==0.25.3
 pytest-cov==6.1.1
 httpx==0.28.1
+
+# SQLite async driver for integration tests (replaces asyncpg in CI/local)
+aiosqlite==0.20.0

--- a/backend/tests/test_cycle_service.py
+++ b/backend/tests/test_cycle_service.py
@@ -1,0 +1,256 @@
+from datetime import date, datetime
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.cycle_service import (
+    create_cycle,
+    get_cycles_by_user,
+    get_cycle_by_id,
+    update_cycle,
+    delete_cycle,
+)
+from tests.conftest import MockRow, TEST_USER_ID, TEST_CYCLE_ID
+
+TEST_USER_2_ID = "550e8400-e29b-41d4-a716-446655449999"
+TEST_LOG_ID = "550e8400-e29b-41d4-a716-446655440002"
+
+
+def _make_cycle_row(**overrides) -> MockRow:
+    return MockRow({
+        "id": overrides.get("id", TEST_CYCLE_ID),
+        "user_id": overrides.get("user_id", TEST_USER_ID),
+        "start_date": overrides.get("start_date", date(2025, 6, 1)),
+        "end_date": overrides.get("end_date", date(2025, 6, 5)),
+        "created_at": overrides.get("created_at", datetime(2025, 6, 1, 12, 0, 0)),
+        "updated_at": overrides.get("updated_at", datetime(2025, 6, 1, 12, 0, 0)),
+    })
+
+
+def _make_log_row(**overrides) -> MockRow:
+    return MockRow({
+        "id": overrides.get("id", TEST_LOG_ID),
+        "cycle_id": overrides.get("cycle_id", TEST_CYCLE_ID),
+        "date": overrides.get("date", date(2025, 6, 1)),
+        "flow_level": overrides.get("flow_level", "medium"),
+        "temperature": overrides.get("temperature", 36.5),
+        "notes": overrides.get("notes", None),
+    })
+
+
+class TestCreateCycle:
+    @patch("app.services.cycle_service.cycle_repo.get_cycle_by_start_date")
+    @patch("app.services.cycle_service.cycle_repo.create_cycle")
+    async def test_valid_dates(self, mock_create, mock_get):
+        mock_get.return_value = None
+        mock_create.return_value = _make_cycle_row()
+
+        result = await create_cycle(
+            user_id=TEST_USER_ID,
+            data={"start_date": date(2025, 6, 1), "end_date": date(2025, 6, 5)},
+        )
+
+        assert result["duration_days"] == 4
+        assert result["user_id"] == TEST_USER_ID
+        mock_get.assert_awaited_once_with(TEST_USER_ID, date(2025, 6, 1))
+        mock_create.assert_awaited_once()
+
+    @patch("app.services.cycle_service.cycle_repo.get_cycle_by_start_date")
+    async def test_duplicate_start_date(self, mock_get):
+        mock_get.return_value = _make_cycle_row()
+
+        with pytest.raises(HTTPException) as exc:
+            await create_cycle(
+                user_id=TEST_USER_ID,
+                data={"start_date": date(2025, 6, 1)},
+            )
+        assert exc.value.status_code == 409
+        assert "already exists" in exc.value.detail
+
+    @patch("app.services.cycle_service.cycle_repo.get_cycle_by_start_date")
+    @patch("app.services.cycle_service.cycle_repo.create_cycle")
+    async def test_different_user_same_date(self, mock_create, mock_get):
+        async def _side_effect(user_id, start_date):
+            if user_id == TEST_USER_ID:
+                return _make_cycle_row(user_id=TEST_USER_ID)
+            return None
+        mock_get.side_effect = _side_effect
+        mock_create.return_value = _make_cycle_row(user_id=TEST_USER_2_ID)
+
+        result = await create_cycle(
+            user_id=TEST_USER_2_ID,
+            data={"start_date": date(2025, 6, 1)},
+        )
+        assert result["user_id"] == TEST_USER_2_ID
+
+
+class TestGetCyclesByUser:
+    @patch("app.services.cycle_service.cycle_repo.count_cycles")
+    @patch("app.services.cycle_service.cycle_repo.get_cycles_by_user")
+    async def test_returns_cycles(self, mock_get, mock_count):
+        mock_count.return_value = 2
+        mock_get.return_value = [
+            _make_cycle_row(start_date=date(2025, 6, 1)),
+            _make_cycle_row(start_date=date(2025, 5, 1)),
+        ]
+
+        total, cycles = await get_cycles_by_user(TEST_USER_ID)
+        assert total == 2
+        assert len(cycles) == 2
+
+    @patch("app.services.cycle_service.cycle_repo.count_cycles")
+    @patch("app.services.cycle_service.cycle_repo.get_cycles_by_user")
+    async def test_empty_user(self, mock_get, mock_count):
+        mock_count.return_value = 0
+        mock_get.return_value = []
+
+        total, cycles = await get_cycles_by_user(TEST_USER_ID)
+        assert total == 0
+        assert cycles == []
+
+    @patch("app.services.cycle_service.cycle_repo.count_cycles")
+    @patch("app.services.cycle_service.cycle_repo.get_cycles_by_user")
+    async def test_pagination(self, mock_get, mock_count):
+        mock_count.return_value = 5
+        mock_get.return_value = [
+            _make_cycle_row(start_date=date(2025, 6, 1)),
+        ]
+
+        total, cycles = await get_cycles_by_user(TEST_USER_ID, limit=1, offset=2)
+        assert total == 5
+        assert len(cycles) == 1
+        mock_get.assert_awaited_once_with(TEST_USER_ID, 1, 2, None)
+
+    @patch("app.services.cycle_service.cycle_repo.count_cycles")
+    @patch("app.services.cycle_service.cycle_repo.get_cycles_by_user")
+    async def test_from_date_filter(self, mock_get, mock_count):
+        mock_count.return_value = 1
+        mock_get.return_value = [_make_cycle_row()]
+
+        total, cycles = await get_cycles_by_user(TEST_USER_ID, from_date=date(2025, 1, 1))
+        assert total == 1
+        mock_get.assert_awaited_once_with(TEST_USER_ID, 20, 0, date(2025, 1, 1))
+
+
+class TestGetCycleById:
+    @patch("app.services.cycle_service.cycle_repo.get_cycle_by_id")
+    @patch("app.services.cycle_service.get_logs_by_cycle")
+    async def test_found(self, mock_logs, mock_get):
+        mock_get.return_value = _make_cycle_row()
+        mock_logs.return_value = []
+
+        result = await get_cycle_by_id(TEST_CYCLE_ID, TEST_USER_ID)
+        assert result["id"] == TEST_CYCLE_ID
+        assert result["duration_days"] == 4
+        assert result["daily_logs"] == []
+
+    @patch("app.services.cycle_service.cycle_repo.get_cycle_by_id")
+    @patch("app.services.cycle_service.get_logs_by_cycle")
+    async def test_found_with_daily_logs(self, mock_logs, mock_get):
+        mock_get.return_value = _make_cycle_row()
+        mock_logs.return_value = [_make_log_row()]
+
+        result = await get_cycle_by_id(TEST_CYCLE_ID, TEST_USER_ID)
+        assert len(result["daily_logs"]) == 1
+        assert result["daily_logs"][0]["flow_level"] == "medium"
+
+    @patch("app.services.cycle_service.cycle_repo.get_cycle_by_id")
+    async def test_not_found(self, mock_get):
+        mock_get.return_value = None
+
+        with pytest.raises(HTTPException) as exc:
+            await get_cycle_by_id("nonexistent", TEST_USER_ID)
+        assert exc.value.status_code == 404
+
+    @patch("app.services.cycle_service.cycle_repo.get_cycle_by_id")
+    async def test_wrong_user_returns_404(self, mock_get):
+        mock_get.return_value = None
+
+        with pytest.raises(HTTPException) as exc:
+            await get_cycle_by_id(TEST_CYCLE_ID, TEST_USER_2_ID)
+        assert exc.value.status_code == 404
+
+
+class TestUpdateCycle:
+    @patch("app.services.cycle_service.cycle_repo.update_cycle")
+    async def test_update_valid(self, mock_update):
+        mock_update.return_value = _make_cycle_row(end_date=date(2025, 6, 7))
+
+        result = await update_cycle(
+            cycle_id=TEST_CYCLE_ID,
+            user_id=TEST_USER_ID,
+            data={"end_date": date(2025, 6, 7)},
+        )
+        assert result["duration_days"] == 6
+
+    @patch("app.services.cycle_service.cycle_repo.update_cycle")
+    async def test_not_found(self, mock_update):
+        mock_update.return_value = None
+
+        with pytest.raises(HTTPException) as exc:
+            await update_cycle(
+                cycle_id="nonexistent",
+                user_id=TEST_USER_ID,
+                data={"end_date": date(2025, 6, 5)},
+            )
+        assert exc.value.status_code == 404
+
+    @patch("app.services.cycle_service.cycle_repo.update_cycle")
+    async def test_wrong_user_returns_404(self, mock_update):
+        mock_update.return_value = None
+
+        with pytest.raises(HTTPException) as exc:
+            await update_cycle(
+                cycle_id=TEST_CYCLE_ID,
+                user_id=TEST_USER_2_ID,
+                data={"end_date": date(2025, 6, 5)},
+            )
+        assert exc.value.status_code == 404
+
+    @patch("app.services.cycle_service.cycle_repo.get_cycle_by_start_date")
+    @patch("app.services.cycle_service.cycle_repo.update_cycle")
+    async def test_duplicate_start_date(self, mock_update, mock_get):
+        mock_get.return_value = _make_cycle_row(id="other-id")
+
+        with pytest.raises(HTTPException) as exc:
+            await update_cycle(
+                cycle_id=TEST_CYCLE_ID,
+                user_id=TEST_USER_ID,
+                data={"start_date": date(2025, 6, 15)},
+            )
+        assert exc.value.status_code == 409
+        mock_update.assert_not_awaited()
+
+    @patch("app.services.cycle_service.cycle_repo.get_cycle_by_start_date")
+    @patch("app.services.cycle_service.cycle_repo.update_cycle")
+    async def test_update_same_cycle_allowed(self, mock_update, mock_get):
+        mock_get.return_value = _make_cycle_row(id=TEST_CYCLE_ID)
+        mock_update.return_value = _make_cycle_row(end_date=date(2025, 6, 7))
+
+        result = await update_cycle(
+            cycle_id=TEST_CYCLE_ID,
+            user_id=TEST_USER_ID,
+            data={"start_date": date(2025, 6, 1), "end_date": date(2025, 6, 7)},
+        )
+        assert result["duration_days"] == 6
+
+
+class TestDeleteCycle:
+    @patch("app.services.cycle_service.cycle_repo.delete_cycle")
+    async def test_delete_success(self, mock_delete):
+        mock_delete.return_value = True
+
+        await delete_cycle(TEST_CYCLE_ID, TEST_USER_ID)
+        mock_delete.assert_awaited_once_with(TEST_CYCLE_ID, TEST_USER_ID)
+
+    @patch("app.services.cycle_service.cycle_repo.delete_cycle")
+    async def test_not_found(self, mock_delete):
+        mock_delete.return_value = False
+
+        with pytest.raises(HTTPException) as exc:
+            await delete_cycle("nonexistent", TEST_USER_ID)
+        assert exc.value.status_code == 404
+
+
+

--- a/backend/tests/test_cycle_service_integration.py
+++ b/backend/tests/test_cycle_service_integration.py
@@ -1,0 +1,259 @@
+"""
+Tests de integración para cycle_service contra SQLite in-memory.
+
+Usa test_metadata.py (String(36) en vez de UUID) para crear tablas
+compatibles con SQLite y parcha app.core.db.engine + los módulos de
+repositorios que importan engine a nivel de módulo.
+
+Esto permite que el servicio y los repositorios reales ejecuten
+consultas SQL contra una base de datos real (sin mocks), sin
+depender de PostgreSQL.
+
+Motivación de la separación:
+  - test_cycle_service.py  → usa @patch en los repos (unit tests)
+  - test_cycle_service_integration.py  → usa SQLite real (integration tests)
+Ambos archivos cubren los mismos 18 casos; conviene mantenerlos
+sincronizados al agregar nuevas funciones a cycle_service.
+"""
+
+from datetime import date
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import insert
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.repositories import cycle_repo
+from app.services.cycle_service import (
+    create_cycle,
+    get_cycles_by_user,
+    get_cycle_by_id,
+    update_cycle,
+    delete_cycle,
+)
+from tests.conftest import TEST_USER_ID, TEST_CYCLE_ID
+from tests.test_metadata import test_metadata as _tm
+
+TEST_USER_2_ID = "550e8400-e29b-41d4-a716-446655449999"
+TEST_LOG_ID = "550e8400-e29b-41d4-a716-446655440002"
+
+
+@pytest.fixture(autouse=True)
+async def sqlite_engine(monkeypatch):
+    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(_tm.create_all)
+    _cycles = _tm.tables["cycles"]
+    _logs = _tm.tables["daily_logs"]
+    monkeypatch.setattr("app.core.db.engine", engine)
+    monkeypatch.setattr("app.repositories.cycle_repo.engine", engine)
+    monkeypatch.setattr("app.repositories.daily_log_repo.engine", engine)
+    monkeypatch.setattr("app.repositories.symptom_repo.engine", engine)
+    monkeypatch.setattr("app.repositories.cycle_repo.cycles_table", _cycles)
+    monkeypatch.setattr("app.repositories.daily_log_repo.daily_logs_table", _logs)
+    monkeypatch.setattr("app.repositories.cycle_repo.CYCLE_COLUMNS", [
+        _cycles.c.id, _cycles.c.user_id, _cycles.c.start_date,
+        _cycles.c.end_date, _cycles.c.created_at, _cycles.c.updated_at,
+    ])
+    monkeypatch.setattr("app.repositories.daily_log_repo.LOG_COLUMNS", [
+        _logs.c.id, _logs.c.cycle_id, _logs.c.date,
+        _logs.c.flow_level, _logs.c.temperature, _logs.c.notes,
+        _logs.c.created_at, _logs.c.updated_at,
+    ])
+    yield
+    await engine.dispose()
+
+
+@pytest.fixture
+def patched_db():
+    from app.core.db import engine
+    return engine
+
+
+_cycles = _tm.tables["cycles"]
+_daily_logs = _tm.tables["daily_logs"]
+
+
+@pytest.fixture
+async def existing_cycle(sqlite_engine, patched_db):
+    async with patched_db.connect() as conn:
+        await conn.execute(
+            insert(_cycles).values(
+                id=TEST_CYCLE_ID,
+                user_id=TEST_USER_ID,
+                start_date=date(2025, 5, 1),
+                end_date=date(2025, 5, 5),
+            )
+        )
+        await conn.commit()
+
+
+@pytest.fixture
+async def existing_daily_log(sqlite_engine, existing_cycle, patched_db):
+    async with patched_db.connect() as conn:
+        await conn.execute(
+            insert(_daily_logs).values(
+                id=TEST_LOG_ID,
+                cycle_id=TEST_CYCLE_ID,
+                date=date(2025, 5, 1),
+                flow_level="medium",
+            )
+        )
+        await conn.commit()
+
+
+class TestCreateCycle:
+    async def test_valid_dates(self):
+        result = await create_cycle(
+            user_id=TEST_USER_ID,
+            data={"start_date": date(2025, 6, 1), "end_date": date(2025, 6, 5)},
+        )
+        assert result["id"] is not None
+        assert result["user_id"] == TEST_USER_ID
+        assert result["start_date"] == date(2025, 6, 1)
+        assert result["duration_days"] == 4
+
+    async def test_duplicate_start_date(self, existing_cycle):
+        with pytest.raises(HTTPException) as exc:
+            await create_cycle(
+                user_id=TEST_USER_ID,
+                data={"start_date": date(2025, 5, 1)},
+            )
+        assert exc.value.status_code == 409
+        assert "already exists" in exc.value.detail
+
+    async def test_different_user_same_date(self, existing_cycle):
+        result = await create_cycle(
+            user_id=TEST_USER_2_ID,
+            data={"start_date": date(2025, 5, 1)},
+        )
+        assert result["id"] is not None
+        assert result["user_id"] == TEST_USER_2_ID
+
+
+class TestGetCyclesByUser:
+    async def test_returns_only_user_cycles(self, sqlite_engine, patched_db):
+        async with patched_db.connect() as conn:
+            dates = [date(2025, 6, 1), date(2025, 6, 2), date(2025, 6, 1)]
+            for uid, d in zip([TEST_USER_ID, TEST_USER_ID, TEST_USER_2_ID], dates):
+                await conn.execute(
+                    insert(_cycles).values(user_id=uid, start_date=d)
+                )
+            await conn.commit()
+
+        total, cycles = await get_cycles_by_user(TEST_USER_ID)
+        assert total == 2
+        assert all(c["user_id"] == TEST_USER_ID for c in cycles)
+
+    async def test_empty_user(self):
+        total, cycles = await get_cycles_by_user(TEST_USER_ID)
+        assert total == 0
+        assert cycles == []
+
+    async def test_pagination(self, sqlite_engine, patched_db):
+        async with patched_db.connect() as conn:
+            for i in range(5):
+                await conn.execute(
+                    insert(_cycles).values(
+                        user_id=TEST_USER_ID,
+                        start_date=date(2025, 5, 1 + i),
+                    )
+                )
+            await conn.commit()
+
+        total, cycles = await get_cycles_by_user(TEST_USER_ID, limit=2, offset=1)
+        assert total == 5
+        assert len(cycles) == 2
+
+
+class TestGetCycleById:
+    async def test_found(self, existing_cycle):
+        result = await get_cycle_by_id(TEST_CYCLE_ID, TEST_USER_ID)
+        assert result["id"] == TEST_CYCLE_ID
+        assert result["duration_days"] == 4
+
+    async def test_found_with_daily_logs(self, existing_daily_log):
+        result = await get_cycle_by_id(TEST_CYCLE_ID, TEST_USER_ID)
+        assert result["id"] == TEST_CYCLE_ID
+        assert len(result["daily_logs"]) == 1
+        assert result["daily_logs"][0]["flow_level"] == "medium"
+
+    async def test_not_found(self):
+        with pytest.raises(HTTPException) as exc:
+            await get_cycle_by_id("nonexistent-id", TEST_USER_ID)
+        assert exc.value.status_code == 404
+
+    async def test_wrong_user_returns_404(self, existing_cycle):
+        with pytest.raises(HTTPException) as exc:
+            await get_cycle_by_id(TEST_CYCLE_ID, TEST_USER_2_ID)
+        assert exc.value.status_code == 404
+
+
+class TestUpdateCycle:
+    async def test_update_valid(self, existing_cycle):
+        result = await update_cycle(
+            cycle_id=TEST_CYCLE_ID,
+            user_id=TEST_USER_ID,
+            data={"end_date": date(2025, 5, 7)},
+        )
+        assert result["duration_days"] == 6
+
+    async def test_not_found(self):
+        with pytest.raises(HTTPException) as exc:
+            await update_cycle(
+                cycle_id="nonexistent",
+                user_id=TEST_USER_ID,
+                data={"end_date": date(2025, 6, 5)},
+            )
+        assert exc.value.status_code == 404
+
+    async def test_wrong_user_returns_404(self, existing_cycle):
+        with pytest.raises(HTTPException) as exc:
+            await update_cycle(
+                cycle_id=TEST_CYCLE_ID,
+                user_id=TEST_USER_2_ID,
+                data={"end_date": date(2025, 6, 5)},
+            )
+        assert exc.value.status_code == 404
+
+    async def test_duplicate_start_date(self, sqlite_engine, patched_db):
+        async with patched_db.connect() as conn:
+            await conn.execute(
+                insert(_cycles).values(
+                    id=TEST_CYCLE_ID,
+                    user_id=TEST_USER_ID,
+                    start_date=date(2025, 5, 1),
+                )
+            )
+            await conn.execute(
+                insert(_cycles).values(
+                    user_id=TEST_USER_ID,
+                    start_date=date(2025, 6, 1),
+                )
+            )
+            await conn.commit()
+
+        with pytest.raises(HTTPException) as exc:
+            await update_cycle(
+                cycle_id=TEST_CYCLE_ID,
+                user_id=TEST_USER_ID,
+                data={"start_date": date(2025, 6, 1)},
+            )
+        assert exc.value.status_code == 409
+
+
+class TestDeleteCycle:
+    async def test_delete_success(self, existing_cycle):
+        await delete_cycle(TEST_CYCLE_ID, TEST_USER_ID)
+        result = await cycle_repo.get_cycle_by_id(TEST_CYCLE_ID, TEST_USER_ID)
+        assert result is None
+
+    async def test_not_found(self):
+        with pytest.raises(HTTPException) as exc:
+            await delete_cycle("nonexistent", TEST_USER_ID)
+        assert exc.value.status_code == 404
+
+    async def test_wrong_user_returns_404(self, existing_cycle):
+        with pytest.raises(HTTPException) as exc:
+            await delete_cycle(TEST_CYCLE_ID, TEST_USER_2_ID)
+        assert exc.value.status_code == 404

--- a/backend/tests/test_metadata.py
+++ b/backend/tests/test_metadata.py
@@ -1,0 +1,83 @@
+"""
+SQLite-compatible table definitions for integration tests.
+
+Reemplaza UUID -> String(36) y server_defaults de PostgreSQL
+por equivalents que funcionan en SQLite.  Esto permite que los tests
+de integración corran contra SQLite in-memory en vez de depender de
+PostgreSQL real.
+
+Motivación:
+  - Las tablas reales (app.models.db_tables) usan:
+      * Column("id", UUID, server_default=func.gen_random_uuid())
+      * Column("user_id", UUID, ...)
+    lo cual solo funciona con PostgreSQL + asyncpg.
+  - Esta copia usa String(36) + hex(randomblob) para SQLite.
+  - Solo incluye las tablas necesarias para cycle_service; si en el
+    futuro se necesitan más, se agregan acá (misma mecánica).
+"""
+
+from sqlalchemy import (
+    Table, Column, MetaData, String, Date, DateTime,
+    SmallInteger, Text, Numeric, Boolean, Integer,
+    ForeignKey, UniqueConstraint, CheckConstraint, Index,
+    func, text,
+)
+
+test_metadata = MetaData()
+
+cycles_table = Table(
+    "cycles", test_metadata,
+    Column("id", String(36), primary_key=True,
+           server_default=text(
+               "(lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-' || "
+               "hex(randomblob(2)) || '-' || hex(randomblob(2)) || '-' || hex(randomblob(6))))"
+           )),
+    Column("user_id", String(36), nullable=False),
+    Column("start_date", Date, nullable=False),
+    Column("end_date", Date),
+    Column("created_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+    Column("updated_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+    CheckConstraint("end_date IS NULL OR end_date >= start_date", name="chk_cycle_dates"),
+    UniqueConstraint("user_id", "start_date", name="uq_cycle_user_start"),
+    Index("idx_cycles_user_date", "user_id", "start_date"),
+)
+
+daily_logs_table = Table(
+    "daily_logs", test_metadata,
+    Column("id", String(36), primary_key=True,
+           server_default=text(
+               "(lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-' || "
+               "hex(randomblob(2)) || '-' || hex(randomblob(2)) || '-' || hex(randomblob(6))))"
+           )),
+    Column("cycle_id", String(36), nullable=False),
+    Column("date", Date, nullable=False),
+    Column("flow_level", String(10)),
+    Column("temperature", Numeric(4, 2)),
+    Column("notes", Text),
+    Column("created_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+    Column("updated_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+    CheckConstraint("flow_level IN ('none', 'light', 'medium', 'heavy')", name="chk_flow_level"),
+    CheckConstraint("temperature IS NULL OR (temperature >= 35.0 AND temperature <= 42.0)", name="chk_temperature"),
+    UniqueConstraint("cycle_id", "date", name="uq_log_cycle_date"),
+    Index("idx_daily_logs_cycle", "cycle_id", "date"),
+)
+
+symptoms_catalog_table = Table(
+    "symptoms_catalog", test_metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column("name", String(100), unique=True, nullable=False),
+    Column("category", String(20), nullable=False),
+    Column("common_phase", String(20)),
+    CheckConstraint("category IN ('fisica', 'emocional', 'digestiva', 'otra')", name="chk_symptom_category"),
+    CheckConstraint("common_phase IN ('menstruacion', 'folicular', 'ovulacion', 'lutea', 'todas') OR common_phase IS NULL", name="chk_common_phase"),
+)
+
+daily_symptoms_table = Table(
+    "daily_symptoms", test_metadata,
+    Column("log_id", String(36), primary_key=True),
+    Column("symptom_id", Integer, primary_key=True),
+    Column("intensity", SmallInteger, nullable=False),
+    CheckConstraint("intensity BETWEEN 1 AND 5", name="chk_symptom_intensity"),
+    Index("idx_daily_symptoms_log", "log_id"),
+    Index("idx_daily_symptoms_symptom", "symptom_id"),
+)


### PR DESCRIPTION
Isuue #15 
62 tests pasando (1 warning, 0 fallos).
Archivos nuevos
tests/test_metadata.py = Tablas SQLite-compatibles (String(36) en vez de UUID + hex(randomblob) en vez de gen_random_uuid())
tests/test_cycle_service_integrati = 17 tests de integración contra SQLite in-memory — mismos casos que los mocks, pero contra BD real.
Bug encontrado y fixeado
app/services/cycle_service.py — _row_to_dict y _log_row_to_dict asumían que recibían un Row de SQLAlchemy, pero los repositorios devuelven dict(row._mapping) (un dict). Se agregó isinstance(row, dict) check para manejar ambos casos. Sin este fix, el servicio crashearía en producción también.
Estructura
tests/
├── test_cycle_service.py          # 18 tests con @patch (unitarios)
├── test_cycle_service_integration.py  # 17 tests contra SQLite (integración)
├── test_metadata.py               # SQLite-compatible table defs
├── test_models.py                 # 22 tests de esquemas Pydantic (Meriyei)
├── conftest.py                    # Fixtures compartidas (Meriyei)
└── test_placeholder.py            # Placeholder inicial