### PR TITLE
[S4] feat: endpoints de analytics con window functions PostgreSQL

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
-from app.routers import health, cycles, symptoms
+from app.routers import health, cycles, symptoms, analytics
 
 app = FastAPI(
     title="EVA API",
@@ -30,3 +30,4 @@ app.include_router(health.router)
 app.include_router(cycles.router)
 app.include_router(symptoms.symptoms_router)
 app.include_router(symptoms.daily_logs_router)
+app.include_router(analytics.router)

--- a/backend/app/models/analytics.py
+++ b/backend/app/models/analytics.py
@@ -1,0 +1,48 @@
+from datetime import date
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class AnalyticsSummary(BaseModel):
+    total_cycles: int
+    avg_cycle_duration: float
+    avg_period_duration: float
+    cycle_variability_days: float
+    shortest_cycle: Optional[int] = None
+    longest_cycle: Optional[int] = None
+    last_cycle_start: Optional[date] = None
+
+
+class SymptomAnalyticsEntry(BaseModel):
+    symptom_id: int
+    name: str
+    category: str
+    frequency: float
+    avg_intensity: float
+
+
+class AnalyticsSymptoms(BaseModel):
+    symptoms: list[SymptomAnalyticsEntry]
+    cycles_analyzed: int
+    total_logs_analyzed: int
+
+
+class FlowDistributionEntry(BaseModel):
+    phase: str
+    flow_level: str
+    count: int
+
+
+class AnalyticsFlow(BaseModel):
+    distribution: list[FlowDistributionEntry]
+    total_days_analyzed: int
+
+
+class AnalyticsPhases(BaseModel):
+    avg_menstruation_days: float
+    avg_follicular_days: float
+    avg_ovulation_days: float
+    avg_luteal_days: float
+    avg_cycle_length: float
+    note: str = "Fases folicular y lutea estimadas con modelo proporcional de 28 dias"

--- a/backend/app/repositories/analytics_repo.py
+++ b/backend/app/repositories/analytics_repo.py
@@ -1,0 +1,152 @@
+from sqlalchemy import select, func, case, cast, Integer, Numeric
+from sqlalchemy.sql import text
+
+from app.core.db import engine
+from app.models.db_tables import (
+    cycles_table,
+    daily_logs_table,
+    daily_symptoms_table,
+    symptoms_catalog_table,
+)
+
+
+async def get_cycle_stats(user_id: str) -> dict | None:
+    lead_start = func.lead(cycles_table.c.start_date).over(
+        partition_by=cycles_table.c.user_id,
+        order_by=cycles_table.c.start_date,
+    )
+    duration_expr = cast(lead_start - cycles_table.c.start_date, Integer).label("duration")
+    subq = (
+        select(cycles_table.c.start_date, duration_expr)
+        .where(cycles_table.c.user_id == user_id)
+    ).subquery("cycle_durations")
+
+    query = select(
+        func.count().label("total_cycles"),
+        func.coalesce(func.round(func.avg(subq.c.duration).cast(Numeric), 1).cast(Numeric), 0).label("avg_duration"),
+        func.coalesce(func.round(func.stddev_pop(subq.c.duration).cast(Numeric), 1).cast(Numeric), 0).label("variability"),
+        func.min(subq.c.duration).label("shortest"),
+        func.max(subq.c.duration).label("longest"),
+        func.max(subq.c.start_date).label("last_start"),
+    ).select_from(subq).where(subq.c.duration.isnot(None))
+
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        row = result.one()
+        return dict(row._mapping)
+
+
+async def get_cycle_count(user_id: str) -> int:
+    query = select(func.count()).select_from(cycles_table).where(cycles_table.c.user_id == user_id)
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return result.scalar_one()
+
+
+async def get_bleeding_days_per_cycle(user_id: str) -> list[int]:
+    query = (
+        select(func.count().label("days"))
+        .select_from(daily_logs_table.join(cycles_table, daily_logs_table.c.cycle_id == cycles_table.c.id))
+        .where(cycles_table.c.user_id == user_id, daily_logs_table.c.flow_level.in_(["light", "medium", "heavy"]))
+        .group_by(cycles_table.c.id)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return [r.days for r in result.fetchall()]
+
+
+async def get_last_cycle_ids(user_id: str, limit: int) -> list[str]:
+    query = (
+        select(cycles_table.c.id)
+        .where(cycles_table.c.user_id == user_id)
+        .order_by(cycles_table.c.start_date.desc())
+        .limit(limit)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return [str(r.id) for r in result.fetchall()]
+
+
+async def get_all_cycle_ids(user_id: str) -> list[str]:
+    query = (
+        select(cycles_table.c.id)
+        .where(cycles_table.c.user_id == user_id)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return [str(r.id) for r in result.fetchall()]
+
+
+async def count_logs_for_cycles(cycle_ids: list[str]) -> int:
+    if not cycle_ids:
+        return 0
+    query = (
+        select(func.count(func.distinct(daily_logs_table.c.id)))
+        .select_from(daily_logs_table)
+        .where(daily_logs_table.c.cycle_id.in_(cycle_ids))
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return result.scalar_one()
+
+
+async def get_symptom_frequencies(cycle_ids: list[str], limit: int) -> list[dict]:
+    if not cycle_ids:
+        return []
+    query = (
+        select(
+            symptoms_catalog_table.c.id.label("symptom_id"),
+            symptoms_catalog_table.c.name,
+            symptoms_catalog_table.c.category,
+            func.count(daily_symptoms_table.c.symptom_id).label("occurrences"),
+            func.round(func.avg(cast(daily_symptoms_table.c.intensity, Numeric)), 2).label("avg_intensity"),
+        )
+        .select_from(
+            daily_symptoms_table
+            .join(daily_logs_table, daily_symptoms_table.c.log_id == daily_logs_table.c.id)
+            .join(symptoms_catalog_table, daily_symptoms_table.c.symptom_id == symptoms_catalog_table.c.id)
+        )
+        .where(daily_logs_table.c.cycle_id.in_(cycle_ids))
+        .group_by(symptoms_catalog_table.c.id, symptoms_catalog_table.c.name, symptoms_catalog_table.c.category)
+        .order_by(func.count(daily_symptoms_table.c.symptom_id).desc())
+        .limit(limit)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return [dict(r._mapping) for r in result.fetchall()]
+
+
+async def get_flow_distribution(user_id: str) -> list[dict]:
+    day_of_cycle = cast(daily_logs_table.c.date - cycles_table.c.start_date, Integer) + 1
+    phase_expr = case(
+        (day_of_cycle.between(1, 5), "menstruacion"),
+        (day_of_cycle.between(6, 13), "folicular"),
+        (day_of_cycle.between(14, 16), "ovulacion"),
+        else_="lutea",
+    ).label("phase")
+
+    query = (
+        select(
+            phase_expr,
+            func.coalesce(daily_logs_table.c.flow_level, "none").label("flow_level"),
+            func.count().label("count"),
+        )
+        .select_from(daily_logs_table.join(cycles_table, daily_logs_table.c.cycle_id == cycles_table.c.id))
+        .where(cycles_table.c.user_id == user_id)
+        .group_by(text("phase"), daily_logs_table.c.flow_level)
+        .order_by(text("phase"), daily_logs_table.c.flow_level)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return [dict(r._mapping) for r in result.fetchall()]
+
+
+async def count_logs_for_user(user_id: str) -> int:
+    query = (
+        select(func.count())
+        .select_from(daily_logs_table.join(cycles_table, daily_logs_table.c.cycle_id == cycles_table.c.id))
+        .where(cycles_table.c.user_id == user_id)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return result.scalar_one()

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -1,0 +1,42 @@
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from app.core.security import get_current_user
+from app.models.analytics import (
+    AnalyticsSummary,
+    AnalyticsSymptoms,
+    AnalyticsFlow,
+    AnalyticsPhases,
+)
+from app.services import analytics_service
+
+router = APIRouter(prefix="/analytics", tags=["analytics"])
+
+
+@router.get("/summary", response_model=AnalyticsSummary)
+async def analytics_summary(current_user: dict = Depends(get_current_user)):
+    return await analytics_service.get_summary(user_id=current_user["user_id"])
+
+
+@router.get("/symptoms", response_model=AnalyticsSymptoms)
+async def analytics_symptoms(
+    cycles_back: Optional[int] = Query(None, ge=1, description="Ultimos N ciclos a analizar"),
+    limit: int = Query(10, ge=1, le=30),
+    current_user: dict = Depends(get_current_user),
+):
+    return await analytics_service.get_symptoms_analytics(
+        user_id=current_user["user_id"],
+        cycles_back=cycles_back,
+        limit=limit,
+    )
+
+
+@router.get("/flow", response_model=AnalyticsFlow)
+async def analytics_flow(current_user: dict = Depends(get_current_user)):
+    return await analytics_service.get_flow_analytics(user_id=current_user["user_id"])
+
+
+@router.get("/phases", response_model=AnalyticsPhases)
+async def analytics_phases(current_user: dict = Depends(get_current_user)):
+    return await analytics_service.get_phases_analytics(user_id=current_user["user_id"])

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,6 +1,7 @@
-from app.services import cycle_service, symptom_service
+from app.services import cycle_service, symptom_service, analytics_service
 
 __all__ = [
     "cycle_service",
     "symptom_service",
+    "analytics_service",
 ]

--- a/backend/app/services/analytics_service.py
+++ b/backend/app/services/analytics_service.py
@@ -1,0 +1,99 @@
+from typing import Optional
+
+from app.repositories.analytics_repo import (
+    get_cycle_stats,
+    get_cycle_count,
+    get_bleeding_days_per_cycle,
+    get_last_cycle_ids,
+    get_all_cycle_ids,
+    count_logs_for_cycles,
+    get_symptom_frequencies,
+    get_flow_distribution,
+    count_logs_for_user,
+)
+
+
+async def get_summary(user_id: str) -> dict:
+    total_cycles = await get_cycle_count(user_id)
+    if total_cycles == 0:
+        return {
+            "total_cycles": 0,
+            "avg_cycle_duration": 0.0,
+            "avg_period_duration": 0.0,
+            "cycle_variability_days": 0.0,
+            "shortest_cycle": None,
+            "longest_cycle": None,
+            "last_cycle_start": None,
+        }
+    stats = await get_cycle_stats(user_id)
+    bleeding_days = await get_bleeding_days_per_cycle(user_id)
+    avg_period = round(sum(bleeding_days) / len(bleeding_days), 1) if bleeding_days else 0.0
+    return {
+        "total_cycles": total_cycles,
+        "avg_cycle_duration": float(stats["avg_duration"]) if stats["avg_duration"] else 0.0,
+        "avg_period_duration": avg_period,
+        "cycle_variability_days": float(stats["variability"]) if stats["variability"] else 0.0,
+        "shortest_cycle": stats["shortest"],
+        "longest_cycle": stats["longest"],
+        "last_cycle_start": stats["last_start"],
+    }
+
+
+async def get_symptoms_analytics(user_id: str, cycles_back: Optional[int], limit: int) -> dict:
+    if cycles_back:
+        cycle_ids = await get_last_cycle_ids(user_id, cycles_back)
+    else:
+        cycle_ids = await get_all_cycle_ids(user_id)
+    cycles_analyzed = len(cycle_ids)
+    if cycles_analyzed == 0:
+        return {"symptoms": [], "cycles_analyzed": 0, "total_logs_analyzed": 0}
+    total_logs = await count_logs_for_cycles(cycle_ids)
+    symptom_rows = await get_symptom_frequencies(cycle_ids, limit)
+    symptoms = []
+    for row in symptom_rows:
+        freq = float(row["occurrences"]) / total_logs if total_logs > 0 else 0.0
+        symptoms.append({
+            "symptom_id": row["symptom_id"],
+            "name": row["name"],
+            "category": row["category"],
+            "frequency": round(freq, 4),
+            "avg_intensity": float(row["avg_intensity"]) if row["avg_intensity"] else 0.0,
+        })
+    return {
+        "symptoms": symptoms,
+        "cycles_analyzed": cycles_analyzed,
+        "total_logs_analyzed": total_logs,
+    }
+
+
+async def get_flow_analytics(user_id: str) -> dict:
+    distribution = await get_flow_distribution(user_id)
+    total = await count_logs_for_user(user_id)
+    return {"distribution": distribution, "total_days_analyzed": total}
+
+
+async def get_phases_analytics(user_id: str) -> dict:
+    total_cycles = await get_cycle_count(user_id)
+    if total_cycles == 0:
+        return {
+            "avg_menstruation_days": 0.0,
+            "avg_follicular_days": 0.0,
+            "avg_ovulation_days": 0.0,
+            "avg_luteal_days": 0.0,
+            "avg_cycle_length": 0.0,
+        }
+    stats = await get_cycle_stats(user_id)
+    avg_cycle_length = float(stats["avg_duration"]) if stats["avg_duration"] else 0.0
+    bleeding_days = await get_bleeding_days_per_cycle(user_id)
+    avg_bleeding = round(sum(bleeding_days) / len(bleeding_days), 1) if bleeding_days else 5.0
+    if avg_cycle_length > 0:
+        scale = avg_cycle_length / 28.0
+    else:
+        scale = 1.0
+    return {
+        "avg_menstruation_days": avg_bleeding,
+        "avg_follicular_days": round(9.0 * scale, 1),
+        "avg_ovulation_days": 3.0,
+        "avg_luteal_days": round(14.0 * scale, 1),
+        "avg_cycle_length": avg_cycle_length,
+    }

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -156,6 +156,11 @@ async def sqlite_engine(monkeypatch):
     monkeypatch.setattr("app.repositories.cycle_repo.engine", engine)
     monkeypatch.setattr("app.repositories.daily_log_repo.engine", engine)
     monkeypatch.setattr("app.repositories.symptom_repo.engine", engine)
+    monkeypatch.setattr("app.repositories.analytics_repo.engine", engine)
+    monkeypatch.setattr("app.repositories.analytics_repo.cycles_table", _tm.tables["cycles"])
+    monkeypatch.setattr("app.repositories.analytics_repo.daily_logs_table", _tm.tables["daily_logs"])
+    monkeypatch.setattr("app.repositories.analytics_repo.daily_symptoms_table", _tm.tables["daily_symptoms"])
+    monkeypatch.setattr("app.repositories.analytics_repo.symptoms_catalog_table", _tm.tables["symptoms_catalog"])
 
     monkeypatch.setattr(
         "app.repositories.cycle_repo.cycles_table", _tm.tables["cycles"]

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -1,0 +1,125 @@
+import pytest
+from unittest.mock import patch
+
+from app.services.analytics_service import (
+    get_summary,
+    get_symptoms_analytics,
+    get_flow_analytics,
+    get_phases_analytics,
+)
+
+USER_ID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+class TestEmptyUser:
+    """Usuario sin ciclos — todos los endpoints deben retornar datos vacios/ceros sin lanzar 500."""
+
+    @pytest.mark.asyncio
+    @patch("app.services.analytics_service.get_cycle_count")
+    async def test_summary_empty(self, mock_count):
+        mock_count.return_value = 0
+        result = await get_summary(USER_ID)
+        assert result["total_cycles"] == 0
+        assert result["avg_cycle_duration"] == 0.0
+        assert result["avg_period_duration"] == 0.0
+        assert result["cycle_variability_days"] == 0.0
+        assert result["shortest_cycle"] is None
+        assert result["longest_cycle"] is None
+        assert result["last_cycle_start"] is None
+
+    @pytest.mark.asyncio
+    @patch("app.services.analytics_service.get_all_cycle_ids")
+    async def test_symptoms_empty(self, mock_ids):
+        mock_ids.return_value = []
+        result = await get_symptoms_analytics(USER_ID, cycles_back=None, limit=10)
+        assert result["symptoms"] == []
+        assert result["cycles_analyzed"] == 0
+        assert result["total_logs_analyzed"] == 0
+
+    @pytest.mark.asyncio
+    @patch("app.services.analytics_service.get_last_cycle_ids")
+    async def test_symptoms_with_cycles_back(self, mock_ids):
+        mock_ids.return_value = []
+        result = await get_symptoms_analytics(USER_ID, cycles_back=3, limit=10)
+        assert result["symptoms"] == []
+        assert result["cycles_analyzed"] == 0
+        mock_ids.assert_called_once_with(USER_ID, 3)
+
+    @pytest.mark.asyncio
+    @patch("app.services.analytics_service.get_flow_distribution")
+    @patch("app.services.analytics_service.count_logs_for_user")
+    async def test_flow_empty(self, mock_count, mock_dist):
+        mock_dist.return_value = []
+        mock_count.return_value = 0
+        result = await get_flow_analytics(USER_ID)
+        assert result["distribution"] == []
+        assert result["total_days_analyzed"] == 0
+
+    @pytest.mark.asyncio
+    @patch("app.services.analytics_service.get_cycle_count")
+    async def test_phases_empty(self, mock_count):
+        mock_count.return_value = 0
+        result = await get_phases_analytics(USER_ID)
+        assert result["avg_menstruation_days"] == 0.0
+        assert result["avg_follicular_days"] == 0.0
+        assert result["avg_ovulation_days"] == 0.0
+        assert result["avg_luteal_days"] == 0.0
+        assert result["avg_cycle_length"] == 0.0
+
+
+class TestSchemaValidation:
+    """Validacion de schemas Pydantic para los endpoints de analytics."""
+
+    def test_summary_schema_valid(self):
+        from app.models.analytics import AnalyticsSummary
+        s = AnalyticsSummary(
+            total_cycles=0,
+            avg_cycle_duration=0.0,
+            avg_period_duration=0.0,
+            cycle_variability_days=0.0,
+            shortest_cycle=None,
+            longest_cycle=None,
+            last_cycle_start=None,
+        )
+        assert s.total_cycles == 0
+
+    def test_symptoms_schema_valid(self):
+        from app.models.analytics import AnalyticsSymptoms
+        s = AnalyticsSymptoms(symptoms=[], cycles_analyzed=0, total_logs_analyzed=0)
+        assert s.symptoms == []
+
+    def test_flow_schema_valid(self):
+        from app.models.analytics import AnalyticsFlow
+        s = AnalyticsFlow(distribution=[], total_days_analyzed=0)
+        assert s.distribution == []
+
+    def test_phases_schema_valid(self):
+        from app.models.analytics import AnalyticsPhases
+        s = AnalyticsPhases(
+            avg_menstruation_days=0.0,
+            avg_follicular_days=0.0,
+            avg_ovulation_days=0.0,
+            avg_luteal_days=0.0,
+            avg_cycle_length=0.0,
+        )
+        assert "estimadas" in s.note
+
+
+class TestPhasesCalculation:
+    """Calculo de fases con datos reales."""
+
+    @pytest.mark.asyncio
+    @patch("app.services.analytics_service.get_cycle_count")
+    @patch("app.services.analytics_service.get_cycle_stats")
+    @patch("app.services.analytics_service.get_bleeding_days_per_cycle")
+    async def test_phases_with_data(self, mock_bleeding, mock_stats, mock_count):
+        mock_count.return_value = 5
+        mock_stats.return_value = {"avg_duration": 27.5, "variability": 2.1, "shortest": 25, "longest": 30, "last_start": None}
+        mock_bleeding.return_value = [5, 4, 6, 5, 5]
+        result = await get_phases_analytics(USER_ID)
+        assert result["avg_menstruation_days"] == 5.0
+        assert result["avg_cycle_length"] == 27.5
+        assert result["avg_ovulation_days"] == 3.0
+        scale = 27.5 / 28.0
+        assert result["avg_follicular_days"] == round(9.0 * scale, 1)
+        assert result["avg_luteal_days"] == round(14.0 * scale, 1)

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,8 +1,7 @@
-<<<<<<< HEAD
 /* ───── Ciclos ───── */
 
 export interface CycleCreate {
-  start_date: string;  // "YYYY-MM-DD"
+  start_date: string;
   end_date?: string;
 }
 
@@ -41,7 +40,7 @@ export interface SymptomResponse {
 
 export interface SymptomEntry {
   symptom_id: number;
-  intensity: number;  // 1-5
+  intensity: number;
 }
 
 export interface SymptomLogEntry extends SymptomEntry {
@@ -94,7 +93,10 @@ export interface AuthSession {
     id: string;
     email: string | undefined;
   };
-=======
+}
+
+/* ───── Phase / Calendar (Daniel S3) ───── */
+
 export type CyclePhase = "menstruacion" | "folicular" | "ovulacion" | "lutea";
 
 export interface Cycle {
@@ -143,5 +145,4 @@ export interface CalendarDay {
   phase: CyclePhase | null;
   cycleId: string | null;
   dailyLog: DailyLog | null;
->>>>>>> origin/DanielS3
 }


### PR DESCRIPTION
## Issue #22 — Endpoints de analytics

### Endpoints nuevos (todos bajo `/analytics`, requieren auth)

| Metodo | Ruta | Query params |
|--------|------|-------------|
| GET | /analytics/summary | - |
| GET | /analytics/symptoms | cycles_back (int), limit (int) |
| GET | /analytics/flow | - |
| GET | /analytics/phases | - |

### Que hace cada uno

- **/summary** — total de ciclos, duracion promedio, variabilidad, mas corto/largo, ultimo inicio
- **/symptoms** — frecuencia de sintomas en los ultimos N ciclos, con intensidad promedio
- **/flow** — distribucion de flujo (none/light/medium/heavy) por fase del ciclo (menstruacion/folicular/ovulacion/lutea)
- **/phases** — duracion promedio estimada de cada fase basada en modelo proporcional de 28 dias

### Usuario sin ciclos
Todos los endpoints retornan datos vacios/ceros (sin 500):
- summary: total_cycles=0, avg_*=0.0, *_cycle=null
- symptoms: symptoms=[], cycles_analyzed=0
- flow: distribution=[], total_days_analyzed=0
- phases: todos los avg_*=0.0, note incluye disclaimer de estimacion proporcional

### Tecnicas SQL
- LEAD window function para calcular duraciones entre ciclos consecutivos
- CASE WHEN para derivar fase segun (log.date - cycle.start_date)
- Cast + Numeric para promedios y frecuencias
- COALESCE para evitar NULLs en agregaciones

### Cambios en test infrastructure
- Agregado analytics_repo al monkeypatch de sqlite_engine en conftest.py
- 10 tests unitarios nuevos en test_analytics.py

### Verificacion
- 72/72 tests pasan (55 existentes + 10 analytics + 7 integracion reparados con greenlet)
- ruff: 0 errores en app/ y tests/
- OpenAPI: 4 endpoints registrados bajo /analytics
- greenlet agregado al venv (necesario para SQLAlchemy async en tests de integracion)