### PR TITLE
[S4] feat: optimización de queries analytics con índices + seed_test_data.py

### DIFF
--- a/backend/app/models/db_tables.py
+++ b/backend/app/models/db_tables.py
@@ -42,7 +42,7 @@ daily_logs_table = Table(
     CheckConstraint("flow_level IN ('none', 'light', 'medium', 'heavy')", name="chk_flow_level"),
     CheckConstraint("temperature IS NULL OR (temperature >= 35.0 AND temperature <= 42.0)", name="chk_temperature"),
     UniqueConstraint("cycle_id", "date", name="uq_log_cycle_date"),
-    Index("idx_daily_logs_cycle", "cycle_id", "date", postgresql_using="btree"),
+    Index("idx_daily_logs_cycle_flow", "cycle_id", "flow_level", postgresql_using="btree"),
 )
 
 symptoms_catalog_table = Table(
@@ -61,7 +61,6 @@ daily_symptoms_table = Table(
     Column("symptom_id", Integer, ForeignKey("symptoms_catalog.id"), primary_key=True),
     Column("intensity", SmallInteger, nullable=False),
     CheckConstraint("intensity BETWEEN 1 AND 5", name="chk_symptom_intensity"),
-    Index("idx_daily_symptoms_log", "log_id"),
     Index("idx_daily_symptoms_symptom", "symptom_id"),
 )
 

--- a/backend/migrations/versions/003_optimize_analytics_indexes.py
+++ b/backend/migrations/versions/003_optimize_analytics_indexes.py
@@ -1,0 +1,42 @@
+"""optimize analytics indexes
+
+Revision ID: 003
+Revises: 002
+Create Date: 2025-07-01
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "003"
+down_revision: Union[str, None] = "002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # DROP redundant indexes
+    # idx_daily_logs_cycle is redundant with unique constraint uq_log_cycle_date (cycle_id, date)
+    op.drop_index("idx_daily_logs_cycle", table_name="daily_logs")
+    # idx_daily_symptoms_log is redundant with PK (log_id, symptom_id)
+    op.drop_index("idx_daily_symptoms_log", table_name="daily_symptoms")
+
+    # NEW composite index for get_bleeding_days_per_cycle
+    # Covers: WHERE cycle_id = ? AND flow_level IN (?, ?, ?)
+    op.create_index(
+        "idx_daily_logs_cycle_flow",
+        "daily_logs",
+        ["cycle_id", "flow_level"],
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_daily_logs_cycle_flow", table_name="daily_logs")
+    op.create_index("idx_daily_symptoms_log", "daily_symptoms", ["log_id"])
+    op.create_index(
+        "idx_daily_logs_cycle", "daily_logs", ["cycle_id", sa.text("date")]
+    )

--- a/backend/scripts/seed_test_data.py
+++ b/backend/scripts/seed_test_data.py
@@ -1,0 +1,205 @@
+"""
+Generate synthetic data for performance testing of analytics queries.
+
+Usage:
+    python scripts/seed_test_data.py
+
+Connects to PostgreSQL via DATABASE_URL from .env.
+Generates: 10 users, 8-15 cycles each (~100), ~500 daily_logs, ~300 daily_symptoms.
+Runs EXPLAIN ANALYZE on the 4 core analytics queries.
+"""
+
+import random
+import os
+import sys
+import uuid
+from datetime import date, timedelta
+
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(os.path.dirname(__file__), "..", ".env"))
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+if not DATABASE_URL:
+    print("ERROR: DATABASE_URL not set in .env")
+    sys.exit(1)
+
+USERS_COUNT = 10
+CYCLES_PER_USER = (8, 15)
+CYCLE_LENGTH_RANGE = (24, 35)
+PERIOD_LENGTH_RANGE = (4, 7)
+SYMPTOMS_PER_LOG = (1, 2)
+USER_ID_BASE = "aaaaaaaa-bbbb-cccc-dddd-"
+
+
+def random_user_id(i: int) -> str:
+    return f"{USER_ID_BASE}{i:012d}"
+
+
+def main() -> None:
+    from psycopg2.extras import execute_values
+
+    print("Generating synthetic data...")
+
+    user_rows: list[tuple] = []
+    cycle_rows: list[tuple] = []
+    log_rows: list[tuple] = []
+    symptom_rows: list[tuple] = []
+
+    for i in range(1, USERS_COUNT + 1):
+        user_id = random_user_id(i)
+        user_rows.append((user_id, f"test{i}@example.com", date(1990, 1, 1)))
+
+        count = random.randint(*CYCLES_PER_USER)
+        base = date(2023, 1, 1) + timedelta(days=random.randint(0, 365))
+        current = base
+
+        for _ in range(count):
+            duration = random.randint(*CYCLE_LENGTH_RANGE)
+            period = random.randint(*PERIOD_LENGTH_RANGE)
+            end_date = current + timedelta(days=period - 1)
+            cycle_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, f"{user_id}-{current.isoformat()}"))
+
+            cycle_rows.append((cycle_id, user_id, current, end_date))
+
+            for day_offset in range(period):
+                log_date = current + timedelta(days=day_offset)
+                log_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, f"{cycle_id}-{log_date.isoformat()}"))
+                flow = random.choice(["light", "medium", "heavy"])
+                temp = round(random.uniform(36.1, 37.2), 2) if random.random() > 0.3 else None
+
+                log_rows.append((log_id, cycle_id, log_date, flow, temp))
+
+                for _ in range(random.randint(*SYMPTOMS_PER_LOG)):
+                    symptom_rows.append((log_id, random.randint(1, 30), random.randint(1, 5)))
+
+            current = current + timedelta(days=duration)
+
+    print(f"  Users: {len(user_rows)}")
+    print(f"  Cycles: {len(cycle_rows)}")
+    print(f"  Daily logs: {len(log_rows)}")
+    print(f"  Daily symptoms: {len(symptom_rows)}")
+    print()
+
+    import psycopg2
+    conn = psycopg2.connect(DATABASE_URL)
+    cur = conn.cursor()
+
+    print("Inserting...")
+    execute_values(cur, "INSERT INTO users (id, email, birth_date) VALUES %s ON CONFLICT DO NOTHING", user_rows, page_size=100)
+    conn.commit()
+    print(f"  {len(user_rows)} users OK")
+
+    execute_values(cur, "INSERT INTO cycles (id, user_id, start_date, end_date) VALUES %s ON CONFLICT DO NOTHING", cycle_rows, page_size=100)
+    conn.commit()
+    print(f"  {len(cycle_rows)} cycles OK")
+
+    execute_values(cur, "INSERT INTO daily_logs (id, cycle_id, date, flow_level, temperature) VALUES %s ON CONFLICT DO NOTHING", log_rows, page_size=100)
+    conn.commit()
+    print(f"  {len(log_rows)} logs OK")
+
+    execute_values(cur, "INSERT INTO daily_symptoms (log_id, symptom_id, intensity) VALUES %s ON CONFLICT DO NOTHING", symptom_rows, page_size=100)
+    conn.commit()
+    print(f"  {len(symptom_rows)} symptoms OK")
+
+    cur.close()
+    conn.close()
+
+    print()
+    print("Running EXPLAIN ANALYZE...")
+    print("=" * 70)
+
+    test_user_id = random_user_id(1)
+
+    from sqlalchemy import create_engine, text
+    url = DATABASE_URL
+    if url.startswith("postgresql://"):
+        url = url.replace("postgresql://", "postgresql+psycopg2://", 1)
+    engine = create_engine(url, echo=False, connect_args={"connect_timeout": 15})
+
+    with engine.connect() as conn:
+        print("\n--- Q1: get_cycle_stats (LEAD window + aggregation) ---")
+        r = conn.execute(text("""
+            EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+            WITH cycle_durations AS (
+                SELECT start_date,
+                       (LEAD(start_date) OVER (
+                           PARTITION BY user_id ORDER BY start_date
+                       ) - start_date)::int AS duration
+                FROM cycles
+                WHERE user_id = :uid
+            )
+            SELECT count(*) AS total_cycles,
+                   coalesce(round(avg(duration), 1), 0) AS avg_duration,
+                   coalesce(round(stddev_pop(duration), 1), 0) AS variability,
+                   min(duration) AS shortest,
+                   max(duration) AS longest,
+                   max(start_date) AS last_start
+            FROM cycle_durations
+            WHERE duration IS NOT NULL
+        """), {"uid": test_user_id})
+        for row in r.fetchall():
+            print(row[0])
+
+        print("\n--- Q2: get_bleeding_days_per_cycle ---")
+        r = conn.execute(text("""
+            EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+            SELECT c.id AS cycle_id, COUNT(*) AS days
+            FROM daily_logs dl
+            JOIN cycles c ON dl.cycle_id = c.id
+            WHERE c.user_id = :uid
+              AND dl.flow_level IN ('light', 'medium', 'heavy')
+            GROUP BY c.id
+        """), {"uid": test_user_id})
+        for row in r.fetchall():
+            print(row[0])
+
+        print("\n--- Q3: get_symptom_frequencies ---")
+        r = conn.execute(text("""
+            EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+            SELECT sc.id AS symptom_id, sc.name, sc.category,
+                   COUNT(ds.symptom_id) AS occurrences,
+                   ROUND(AVG(ds.intensity::numeric), 2) AS avg_intensity
+            FROM daily_symptoms ds
+            JOIN daily_logs dl ON ds.log_id = dl.id
+            JOIN symptoms_catalog sc ON ds.symptom_id = sc.id
+            WHERE dl.cycle_id IN (
+                SELECT id FROM cycles WHERE user_id = :uid
+                ORDER BY start_date DESC LIMIT 3
+            )
+            GROUP BY sc.id, sc.name, sc.category
+            ORDER BY COUNT(ds.symptom_id) DESC
+            LIMIT 10
+        """), {"uid": test_user_id})
+        for row in r.fetchall():
+            print(row[0])
+
+        print("\n--- Q4: get_flow_distribution ---")
+        r = conn.execute(text("""
+            EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+            SELECT
+                CASE
+                    WHEN (dl.date - c.start_date + 1) BETWEEN 1 AND 5 THEN 'menstruacion'
+                    WHEN (dl.date - c.start_date + 1) BETWEEN 6 AND 13 THEN 'folicular'
+                    WHEN (dl.date - c.start_date + 1) BETWEEN 14 AND 16 THEN 'ovulacion'
+                    ELSE 'lutea'
+                END AS phase,
+                COALESCE(dl.flow_level, 'none') AS flow_level,
+                COUNT(*) AS count
+            FROM daily_logs dl
+            JOIN cycles c ON dl.cycle_id = c.id
+            WHERE c.user_id = :uid
+            GROUP BY phase, dl.flow_level
+            ORDER BY phase, dl.flow_level
+        """), {"uid": test_user_id})
+        for row in r.fetchall():
+            print(row[0])
+
+    engine.dispose()
+    print()
+    print("=" * 70)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Issue #23 — Optimización de queries analytics con índices

### Cambios

**Migración `003_optimize_analytics_indexes.py`:**
- DROP `idx_daily_logs_cycle` (redundante con unique constraint `uq_log_cycle_date`)
- DROP `idx_daily_symptoms_log` (redundante con PK compuesta `(log_id, symptom_id)`)
- CREATE `idx_daily_logs_cycle_flow ON daily_logs(cycle_id, flow_level)`

**Nuevo: `scripts/seed_test_data.py`**
- Genera 10 usuarios, ~100 ciclos, ~550 daily_logs, ~830 daily_symptoms
- Ejecuta EXPLAIN ANALYZE en las 4 queries de analytics
- Conecta vía `DATABASE_URL` desde `.env`

### Resultados EXPLAIN ANALYZE

| Query | Tiempo | Seq Scan | Index |
|-------|--------|----------|-------|
| Q1: get_cycle_stats | 0.574ms | No | `idx_cycles_user_date` (Index Only Scan) |
| Q2: get_bleeding_days_per_cycle | **0.178ms** | **No** (antes sí) | `idx_daily_logs_cycle_flow` (Index Only Scan) |
| Q3: get_symptom_frequencies | 0.914ms | No | `idx_daily_symptoms_symptom` + `uq_log_cycle_date` |
| Q4: get_flow_distribution | 0.312ms | Sí (aceptable) | `idx_cycles_user_date` |

**Q2 mejoró:** 0.289ms → 0.178ms (-38%) eliminando Seq Scan en daily_logs

### Criterios verificados
- [x] EXPLAIN ANALYZE ejecutado en las 4 queries
- [x] Q1, Q2, Q3: sin Seq Scan en tablas grandes
- [x] Q4: Seq Scan aceptable (necesita escaneo completo por el GROUP BY computado)
- [x] Todas las queries < 1ms con 550 logs (target: < 200ms)
- [x] Migración creada y ejecutada contra Supabase
- [x] Script seed_test_data.py funcional
- [x] 72/72 tests pasan, ruff 0 errores en archivos nuevos