### PR TITLE
 [S5] feat: prediccion heuristica basica — GET /predictions/next

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
-from app.routers import health, cycles, symptoms, analytics
+from app.routers import health, cycles, symptoms, analytics, predictions
 
 app = FastAPI(
     title="EVA API",
@@ -31,3 +31,4 @@ app.include_router(cycles.router)
 app.include_router(symptoms.symptoms_router)
 app.include_router(symptoms.daily_logs_router)
 app.include_router(analytics.router)
+app.include_router(predictions.router)

--- a/backend/app/models/prediction.py
+++ b/backend/app/models/prediction.py
@@ -1,0 +1,24 @@
+from datetime import date
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class ConfidenceRange(BaseModel):
+    early: Optional[date] = None
+    late: Optional[date] = None
+
+
+class FertileWindow(BaseModel):
+    start: Optional[date] = None
+    end: Optional[date] = None
+
+
+class PredictionResponse(BaseModel):
+    predicted_start_date: Optional[date] = None
+    confidence_range: ConfidenceRange = ConfidenceRange()
+    days_until_next: Optional[int] = None
+    current_phase: Optional[str] = None
+    current_phase_day: Optional[int] = None
+    prediction_source: Optional[str] = None
+    fertile_window: FertileWindow = FertileWindow()

--- a/backend/app/routers/predictions.py
+++ b/backend/app/routers/predictions.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.core.security import get_current_user
+from app.models.prediction import (
+    ConfidenceRange,
+    FertileWindow,
+    PredictionResponse,
+)
+from app.services import prediction_service
+
+router = APIRouter(prefix="/predictions", tags=["predictions"])
+
+
+@router.get("/next", response_model=PredictionResponse)
+async def get_next_prediction(current_user: dict = Depends(get_current_user)):
+    user_id: str = current_user["user_id"]
+    result = await prediction_service.predict_next_cycle_heuristic(user_id)
+
+    if not result["has_sufficient_data"]:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="No hay suficientes datos para generar una prediccion. Registra al menos un ciclo menstrual.",
+        )
+
+    return PredictionResponse(
+        predicted_start_date=result["predicted_start_date"],
+        confidence_range=ConfidenceRange(
+            early=result["confidence_range"]["early"],
+            late=result["confidence_range"]["late"],
+        ),
+        days_until_next=result["days_until_next"],
+        current_phase=result["current_phase"],
+        current_phase_day=result["current_phase_day"],
+        prediction_source=result["prediction_source"],
+        fertile_window=FertileWindow(
+            start=result["fertile_window"]["start"],
+            end=result["fertile_window"]["end"],
+        ),
+    )

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,7 +1,8 @@
-from app.services import cycle_service, symptom_service, analytics_service
+from app.services import cycle_service, symptom_service, analytics_service, prediction_service
 
 __all__ = [
     "cycle_service",
     "symptom_service",
     "analytics_service",
+    "prediction_service",
 ]

--- a/backend/app/services/prediction_service.py
+++ b/backend/app/services/prediction_service.py
@@ -1,6 +1,6 @@
 import math
 from datetime import date, timedelta
-from typing import Optional
+
 
 from app.repositories import cycle_repo
 from app.utils.cycle_utils import calculate_current_phase

--- a/backend/app/services/prediction_service.py
+++ b/backend/app/services/prediction_service.py
@@ -1,0 +1,74 @@
+import math
+from datetime import date, timedelta
+from typing import Optional
+
+from app.repositories import cycle_repo
+from app.utils.cycle_utils import calculate_current_phase
+
+
+async def predict_next_cycle_heuristic(user_id: str) -> dict:
+    rows = await cycle_repo.get_cycles_by_user(user_id, limit=100, offset=0)
+
+    if not rows:
+        phase, phase_day = calculate_current_phase(None)
+        return {
+            "predicted_start_date": None,
+            "confidence_range": {"early": None, "late": None},
+            "avg_cycle_length": 0.0,
+            "cycle_variability": 0.0,
+            "prediction_source": "heuristic",
+            "has_sufficient_data": False,
+            "last_cycle": None,
+            "current_phase": phase,
+            "current_phase_day": phase_day,
+            "fertile_window": {"start": None, "end": None},
+            "days_until_next": None,
+        }
+
+    cycles = [row if isinstance(row, dict) else dict(row._mapping) for row in rows]
+    cycles.sort(key=lambda c: c["start_date"])
+
+    last_cycle = cycles[-1]
+    last_cycle_dict = {
+        "start_date": last_cycle["start_date"],
+        "end_date": last_cycle.get("end_date"),
+    }
+
+    if len(cycles) == 1:
+        avg_cycle_length = 28.0
+        cycle_variability = 0.0
+    else:
+        durations = [
+            (cycles[i]["start_date"] - cycles[i - 1]["start_date"]).days
+            for i in range(1, len(cycles))
+        ]
+        avg_cycle_length = round(sum(durations) / len(durations), 1)
+        variance = sum((d - avg_cycle_length) ** 2 for d in durations) / len(durations)
+        cycle_variability = round(math.sqrt(variance), 1)
+
+    predicted_start_date = last_cycle["start_date"] + timedelta(days=int(round(avg_cycle_length)))
+
+    days_until_next = (predicted_start_date - date.today()).days
+
+    phase, phase_day = calculate_current_phase(last_cycle_dict)
+
+    confidence_early = predicted_start_date - timedelta(days=int(cycle_variability)) if cycle_variability > 0 else None
+    confidence_late = predicted_start_date + timedelta(days=int(cycle_variability)) if cycle_variability > 0 else None
+
+    ovulation_date = predicted_start_date - timedelta(days=14)
+    fertile_start = ovulation_date - timedelta(days=5)
+    fertile_end = ovulation_date + timedelta(days=1)
+
+    return {
+        "predicted_start_date": predicted_start_date,
+        "confidence_range": {"early": confidence_early, "late": confidence_late},
+        "avg_cycle_length": avg_cycle_length,
+        "cycle_variability": cycle_variability,
+        "prediction_source": "heuristic",
+        "has_sufficient_data": True,
+        "last_cycle": last_cycle_dict,
+        "current_phase": phase,
+        "current_phase_day": phase_day,
+        "fertile_window": {"start": fertile_start, "end": fertile_end},
+        "days_until_next": days_until_next,
+    }

--- a/backend/app/utils/cycle_utils.py
+++ b/backend/app/utils/cycle_utils.py
@@ -1,0 +1,38 @@
+from datetime import date
+from typing import Optional
+
+
+def calculate_current_phase(last_cycle: Optional[dict]) -> tuple[Optional[str], Optional[int]]:
+    if last_cycle is None or last_cycle.get("start_date") is None:
+        return None, None
+
+    today = date.today()
+    cycle_start = last_cycle["start_date"]
+    cycle_end = last_cycle.get("end_date")
+
+    if isinstance(cycle_start, str):
+        from datetime import datetime
+        cycle_start = datetime.strptime(cycle_start, "%Y-%m-%d").date()
+    if isinstance(cycle_end, str):
+        from datetime import datetime
+        cycle_end = datetime.strptime(cycle_end, "%Y-%m-%d").date()
+    if isinstance(today, str):
+        from datetime import datetime
+        today = datetime.strptime(today, "%Y-%m-%d").date()
+
+    day_of_cycle = (today - cycle_start).days + 1
+
+    if day_of_cycle < 1:
+        return None, None
+
+    if cycle_end and today <= cycle_end:
+        return "menstruacion", day_of_cycle
+
+    if 1 <= day_of_cycle <= 5:
+        return "menstruacion", day_of_cycle
+    elif 6 <= day_of_cycle <= 13:
+        return "folicular", day_of_cycle
+    elif 14 <= day_of_cycle <= 16:
+        return "ovulacion", day_of_cycle
+    else:
+        return "lutea", day_of_cycle

--- a/backend/tests/test_prediction.py
+++ b/backend/tests/test_prediction.py
@@ -1,0 +1,188 @@
+from datetime import date, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from app.services.prediction_service import predict_next_cycle_heuristic
+from app.utils.cycle_utils import calculate_current_phase
+
+USER_ID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def _make_cycle(start_date: date, end_date: date | None = None) -> dict:
+    return {"start_date": start_date, "end_date": end_date}
+
+
+class TestPredictEmpty:
+    @pytest.mark.asyncio
+    @patch("app.services.prediction_service.cycle_repo.get_cycles_by_user")
+    async def test_zero_cycles_returns_no_data(self, mock_get):
+        mock_get.return_value = []
+        result = await predict_next_cycle_heuristic(USER_ID)
+        assert result["has_sufficient_data"] is False
+        assert result["predicted_start_date"] is None
+        assert result["avg_cycle_length"] == 0.0
+        assert result["cycle_variability"] == 0.0
+        assert result["confidence_range"]["early"] is None
+        assert result["confidence_range"]["late"] is None
+        assert result["prediction_source"] == "heuristic"
+
+
+class TestPredictSingleCycle:
+    @pytest.mark.asyncio
+    @patch("app.services.prediction_service.cycle_repo.get_cycles_by_user")
+    async def test_one_cycle_assumes_28_days(self, mock_get):
+        start = date(2025, 6, 1)
+        mock_get.return_value = [_make_cycle(start, date(2025, 6, 5))]
+        result = await predict_next_cycle_heuristic(USER_ID)
+        assert result["has_sufficient_data"] is True
+        assert result["avg_cycle_length"] == 28.0
+        assert result["cycle_variability"] == 0.0
+        assert result["predicted_start_date"] == date(2025, 6, 29)
+        assert result["confidence_range"]["early"] is None
+        assert result["confidence_range"]["late"] is None
+        assert result["prediction_source"] == "heuristic"
+
+
+class TestPredictMultipleCycles:
+    @pytest.mark.asyncio
+    @patch("app.services.prediction_service.cycle_repo.get_cycles_by_user")
+    async def test_regular_28_day_cycles(self, mock_get):
+        cycles = [
+            _make_cycle(date(2025, 5, 1), date(2025, 5, 5)),
+            _make_cycle(date(2025, 5, 29), date(2025, 6, 2)),
+            _make_cycle(date(2025, 6, 26), date(2025, 6, 30)),
+        ]
+        mock_get.return_value = cycles
+        result = await predict_next_cycle_heuristic(USER_ID)
+        assert result["has_sufficient_data"] is True
+        assert result["avg_cycle_length"] == 28.0
+        assert result["cycle_variability"] == 0.0
+        assert result["predicted_start_date"] == date(2025, 7, 24)
+        assert result["prediction_source"] == "heuristic"
+
+    @pytest.mark.asyncio
+    @patch("app.services.prediction_service.cycle_repo.get_cycles_by_user")
+    async def test_irregular_cycles_sop_like(self, mock_get):
+        cycles = [
+            _make_cycle(date(2025, 1, 1), date(2025, 1, 6)),
+            _make_cycle(date(2025, 2, 5), date(2025, 2, 10)),
+            _make_cycle(date(2025, 3, 10), date(2025, 3, 15)),
+        ]
+        mock_get.return_value = cycles
+        result = await predict_next_cycle_heuristic(USER_ID)
+        assert result["has_sufficient_data"] is True
+        assert result["avg_cycle_length"] == 34.0
+        assert result["cycle_variability"] > 0
+        assert result["predicted_start_date"] == date(2025, 4, 13)
+        assert result["confidence_range"]["early"] is not None
+        assert result["confidence_range"]["late"] is not None
+
+    @pytest.mark.asyncio
+    @patch("app.services.prediction_service.cycle_repo.get_cycles_by_user")
+    async def test_two_cycles_varying_duration(self, mock_get):
+        cycles = [
+            _make_cycle(date(2025, 6, 1), date(2025, 6, 5)),
+            _make_cycle(date(2025, 7, 3), date(2025, 7, 7)),
+        ]
+        mock_get.return_value = cycles
+        result = await predict_next_cycle_heuristic(USER_ID)
+        assert result["avg_cycle_length"] == 32.0
+        assert result["cycle_variability"] == 0.0
+        assert result["predicted_start_date"] == date(2025, 8, 4)
+
+    @pytest.mark.asyncio
+    @patch("app.services.prediction_service.cycle_repo.get_cycles_by_user")
+    async def test_multiple_cycles_with_variability(self, mock_get):
+        cycles = [
+            _make_cycle(date(2025, 1, 1), date(2025, 1, 5)),
+            _make_cycle(date(2025, 1, 28), date(2025, 2, 2)),
+            _make_cycle(date(2025, 3, 1), date(2025, 3, 5)),
+            _make_cycle(date(2025, 3, 30), date(2025, 4, 3)),
+        ]
+        mock_get.return_value = cycles
+        result = await predict_next_cycle_heuristic(USER_ID)
+        assert result["has_sufficient_data"] is True
+        assert result["cycle_variability"] > 0.0
+        assert result["confidence_range"]["early"] is not None
+        assert result["confidence_range"]["late"] is not None
+        assert result["confidence_range"]["early"] < result["predicted_start_date"] < result["confidence_range"]["late"]
+        assert result["prediction_source"] == "heuristic"
+
+
+class TestFertileWindow:
+    @pytest.mark.asyncio
+    @patch("app.services.prediction_service.cycle_repo.get_cycles_by_user")
+    async def test_fertile_window_calculated(self, mock_get):
+        cycles = [
+            _make_cycle(date(2025, 6, 1), date(2025, 6, 5)),
+        ]
+        mock_get.return_value = cycles
+        result = await predict_next_cycle_heuristic(USER_ID)
+        fw = result["fertile_window"]
+        assert fw["start"] is not None
+        assert fw["end"] is not None
+        assert fw["start"] < fw["end"]
+
+
+class TestDaysUntilNext:
+    @pytest.mark.asyncio
+    @patch("app.services.prediction_service.cycle_repo.get_cycles_by_user")
+    async def test_days_until_next_is_int(self, mock_get):
+        cycles = [
+            _make_cycle(date(2025, 6, 1), date(2025, 6, 5)),
+        ]
+        mock_get.return_value = cycles
+        result = await predict_next_cycle_heuristic(USER_ID)
+        assert isinstance(result["days_until_next"], int)
+
+
+class TestCycleUtils:
+    def test_no_cycle_returns_none(self):
+        phase, day = calculate_current_phase(None)
+        assert phase is None
+        assert day is None
+
+    def test_during_period(self):
+        today = date.today()
+        start = today - timedelta(days=2)
+        end = today + timedelta(days=2)
+        cycle = {"start_date": start, "end_date": end}
+        phase, day = calculate_current_phase(cycle)
+        assert phase == "menstruacion"
+        assert day == 3
+
+    def test_follicular_phase(self):
+        start = date.today() - timedelta(days=8)
+        cycle = {"start_date": start, "end_date": start + timedelta(days=4)}
+        phase, day = calculate_current_phase(cycle)
+        assert phase == "folicular"
+        assert day == 9
+
+    def test_ovulation_phase(self):
+        start = date.today() - timedelta(days=14)
+        cycle = {"start_date": start, "end_date": start + timedelta(days=5)}
+        phase, day = calculate_current_phase(cycle)
+        assert phase == "ovulacion"
+        assert day == 15
+
+    def test_luteal_phase(self):
+        start = date.today() - timedelta(days=22)
+        cycle = {"start_date": start, "end_date": start + timedelta(days=5)}
+        phase, day = calculate_current_phase(cycle)
+        assert phase == "lutea"
+        assert day == 23
+
+    def test_string_dates_are_parsed(self):
+        start = date.today() - timedelta(days=2)
+        cycle = {"start_date": start.isoformat(), "end_date": None}
+        phase, day = calculate_current_phase(cycle)
+        assert phase == "menstruacion"
+        assert day == 3
+
+    def test_cycle_without_end_date(self):
+        start = date.today() - timedelta(days=10)
+        cycle = {"start_date": start}
+        phase, day = calculate_current_phase(cycle)
+        assert phase == "folicular"
+        assert day == 11


### PR DESCRIPTION
## Issues
Closes #28, closes #29

## Que hace
Implementa prediccion heuristica de proximo ciclo menstrual (Sprint 5), sin dependencias de Prophet ni ML.

### Archivos nuevos
- `app/services/prediction_service.py` — `predict_next_cycle_heuristic(user_id)`
- `app/routers/predictions.py` — `GET /predictions/next`
- `app/utils/cycle_utils.py` — `calculate_current_phase(last_cycle)`
- `app/models/prediction.py` — schemas Pydantic
- `tests/test_prediction.py` — 15 tests con datos sinteticos

### Archivos modificados
- `app/main.py` — registrado `predictions.router`
- `app/services/__init__.py` — export de `prediction_service`

### Algoritmo
- 0 ciclos → `has_sufficient_data=False` (sin excepcion; endpoint retorna 422)
- 1 ciclo → asume 28 dias, sin variabilidad
- 2+ ciclos → promedio + desviacion estandar de duraciones entre start_date
- Prediccion: `last_start + avg_cycle_length`
- Rango de confianza: `predicted ± cycle_variability`
- Ventana fertil: ovulacion estimada (-14 dias) ± 5/1
- Fase actual: `calculate_current_phase()` — modelo 28 dias estandar

### Tests
87/87 pasando (72 existentes + 15 nuevos). Sin regresiones.

- Caso 0 ciclos
- Caso 1 ciclo
- Casos 2, 3, 4 ciclos con y sin variabilidad
- Caso SOP-like (ciclos irregulares largos)
- Ventana fertil y days_until_next
- `calculate_current_phase`: todas las fases + edge cases

### No toca
- Sin imports de `ml_service.py` ni Prophet (eso es Sprint 7, Joshua)
- Sin queries nuevas en el servicio — usa `cycle_repo.get_cycles_by_user()` existente