### PR TITLE
feat(sync): implementar POST /sync para sincronización offline (#39)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
-from app.routers import health, cycles, symptoms, analytics, predictions
+from app.routers import health, cycles, symptoms, analytics, predictions, sync
 
 app = FastAPI(
     title="EVA API",
@@ -32,3 +32,4 @@ app.include_router(symptoms.symptoms_router)
 app.include_router(symptoms.daily_logs_router)
 app.include_router(analytics.router)
 app.include_router(predictions.router)
+app.include_router(sync.router)

--- a/backend/app/models/db_tables.py
+++ b/backend/app/models/db_tables.py
@@ -96,6 +96,7 @@ sync_operations_table = Table(
     Column("type", String(30), nullable=False),
     Column("payload", Text, nullable=False),
     Column("status", String(20), nullable=False, server_default=func.text("'applied'")),
+    Column("server_id", String(36), nullable=True),
     Column("applied_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
     CheckConstraint("type IN ('CREATE_CYCLE', 'UPDATE_CYCLE', 'DELETE_CYCLE', 'CREATE_DAILY_LOG', 'UPDATE_DAILY_LOG', 'DELETE_DAILY_LOG')", name="chk_sync_type"),
     CheckConstraint("status IN ('applied', 'skipped', 'failed')", name="chk_sync_status"),

--- a/backend/app/models/sync.py
+++ b/backend/app/models/sync.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel
+
+
+class SyncOperation(BaseModel):
+    client_id: str
+    type: Literal[
+        "CREATE_CYCLE",
+        "UPDATE_CYCLE",
+        "DELETE_CYCLE",
+        "CREATE_DAILY_LOG",
+        "UPDATE_DAILY_LOG",
+        "DELETE_DAILY_LOG",
+    ]
+    payload: dict
+    client_timestamp: datetime
+
+
+class SyncRequest(BaseModel):
+    operations: list[SyncOperation]
+
+
+class SyncResult(BaseModel):
+    client_id: str
+    status: Literal["applied", "skipped", "failed"]
+    server_id: Optional[str] = None
+    error: Optional[str] = None
+
+
+class SyncResponse(BaseModel):
+    applied: int
+    skipped: int
+    failed: int
+    results: list[SyncResult]

--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -26,6 +26,12 @@ from app.repositories.symptom_repo import (
     remove_all_symptoms_from_log,
 )
 
+from app.repositories.sync_repo import (
+    find_by_client_id,
+    insert_sync_operation,
+    resolve_client_id,
+)
+
 __all__ = [
     "get_cycles_by_user",
     "get_cycle_by_id",
@@ -48,4 +54,7 @@ __all__ = [
     "add_symptoms_to_log",
     "remove_symptoms_from_log",
     "remove_all_symptoms_from_log",
+    "find_by_client_id",
+    "insert_sync_operation",
+    "resolve_client_id",
 ]

--- a/backend/app/repositories/sync_repo.py
+++ b/backend/app/repositories/sync_repo.py
@@ -1,0 +1,49 @@
+from sqlalchemy import select, insert
+
+from app.core.db import engine
+from app.models.db_tables import sync_operations_table
+
+SYNC_COLUMNS = [
+    sync_operations_table.c.id,
+    sync_operations_table.c.user_id,
+    sync_operations_table.c.client_id,
+    sync_operations_table.c.type,
+    sync_operations_table.c.payload,
+    sync_operations_table.c.status,
+    sync_operations_table.c.server_id,
+    sync_operations_table.c.applied_at,
+]
+
+
+async def find_by_client_id(client_id: str):
+    query = select(*SYNC_COLUMNS).where(
+        sync_operations_table.c.client_id == client_id
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        return result.one_or_none()
+
+
+async def insert_sync_operation(data: dict) -> dict:
+    query = (
+        insert(sync_operations_table)
+        .values(**data)
+        .returning(*SYNC_COLUMNS)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        await conn.commit()
+        row = result.one()
+        return dict(row._mapping)
+
+
+async def resolve_client_id(client_id: str):
+    query = (
+        select(sync_operations_table.c.server_id)
+        .where(sync_operations_table.c.client_id == client_id)
+        .where(sync_operations_table.c.server_id.isnot(None))
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        row = result.one_or_none()
+        return row[0] if row else None

--- a/backend/app/routers/sync.py
+++ b/backend/app/routers/sync.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends
+
+from app.core.security import get_current_user
+from app.models.sync import SyncRequest, SyncResponse
+from app.services import sync_service
+
+router = APIRouter(prefix="/sync", tags=["sync"])
+
+
+@router.post("", response_model=SyncResponse)
+async def sync_operations(
+    body: SyncRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    operations = [
+        {
+            "client_id": op.client_id,
+            "type": op.type,
+            "payload": op.payload,
+            "client_timestamp": op.client_timestamp,
+        }
+        for op in body.operations
+    ]
+    result = await sync_service.process_sync(
+        user_id=current_user["user_id"],
+        operations=operations,
+    )
+    return SyncResponse(**result)

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,8 +1,9 @@
-from app.services import cycle_service, symptom_service, analytics_service, prediction_service
+from app.services import cycle_service, symptom_service, analytics_service, prediction_service, sync_service
 
 __all__ = [
     "cycle_service",
     "symptom_service",
     "analytics_service",
     "prediction_service",
+    "sync_service",
 ]

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -1,0 +1,134 @@
+import json
+from datetime import date
+
+from fastapi import HTTPException
+
+from app.repositories import sync_repo
+from app.services import cycle_service, symptom_service
+
+
+def _convert_dates(payload: dict, date_fields: set[str] | None = None) -> dict:
+    if date_fields is None:
+        date_fields = {"start_date", "end_date", "date"}
+    for key, value in payload.items():
+        if key in date_fields and isinstance(value, str):
+            payload[key] = date.fromisoformat(value)
+    return payload
+
+
+async def _resolve_id(client_id: str, batch_map: dict[str, str]) -> str:
+    if client_id in batch_map:
+        return batch_map[client_id]
+    server_id = await sync_repo.resolve_client_id(client_id)
+    if not server_id:
+        raise ValueError(f"No se encontró server_id para client_id={client_id}")
+    return str(server_id)
+
+
+def _to_dict(row) -> dict:
+    data = dict(row._mapping) if hasattr(row, "_mapping") else row
+    for key in ("id", "user_id", "cycle_id", "server_id"):
+        if key in data and data[key] is not None:
+            data[key] = str(data[key])
+    return data
+
+
+async def process_sync(user_id: str, operations: list[dict]) -> dict:
+    batch_map: dict[str, str] = {}
+    results: list[dict] = []
+    applied = 0
+    skipped = 0
+    failed = 0
+
+    sorted_ops = sorted(operations, key=lambda op: op["client_timestamp"])
+
+    for op in sorted_ops:
+        client_id = op["client_id"]
+        op_type = op["type"]
+        original_payload = dict(op["payload"])
+        payload = dict(op["payload"])
+        error_msg: str | None = None
+        server_id: str | None = None
+        status = "applied"
+
+        existing = await sync_repo.find_by_client_id(client_id)
+        if existing:
+            skipped += 1
+            results.append({
+                "client_id": client_id,
+                "status": "skipped",
+                "server_id": str(existing.server_id) if existing.server_id else None,
+                "error": None,
+            })
+            continue
+
+        try:
+            if op_type == "CREATE_CYCLE":
+                _convert_dates(payload)
+                cycle = await cycle_service.create_cycle(user_id, payload)
+                server_id = cycle["id"]
+                batch_map[client_id] = server_id
+
+            elif op_type == "UPDATE_CYCLE":
+                cycle_client_id = payload.pop("cycle_client_id")
+                server_id = await _resolve_id(cycle_client_id, batch_map)
+                _convert_dates(payload)
+                await cycle_service.update_cycle(server_id, user_id, payload)
+
+            elif op_type == "DELETE_CYCLE":
+                cycle_client_id = payload.pop("cycle_client_id")
+                server_id = await _resolve_id(cycle_client_id, batch_map)
+                await cycle_service.delete_cycle(server_id, user_id)
+
+            elif op_type == "CREATE_DAILY_LOG":
+                cycle_client_id = payload.pop("cycle_client_id")
+                cycle_id = await _resolve_id(cycle_client_id, batch_map)
+                payload["cycle_id"] = cycle_id
+                _convert_dates(payload)
+                log = await symptom_service.create_log(payload, user_id)
+                server_id = log["id"]
+
+            elif op_type == "UPDATE_DAILY_LOG":
+                log_client_id = payload.pop("log_client_id")
+                server_id = await _resolve_id(log_client_id, batch_map)
+                _convert_dates(payload)
+                await symptom_service.update_log(server_id, payload, user_id)
+
+            elif op_type == "DELETE_DAILY_LOG":
+                log_client_id = payload.pop("log_client_id")
+                server_id = await _resolve_id(log_client_id, batch_map)
+                await symptom_service.delete_log(server_id, user_id)
+
+            applied += 1
+
+        except HTTPException as exc:
+            status = "failed"
+            error_msg = exc.detail
+            failed += 1
+        except Exception as exc:
+            status = "failed"
+            error_msg = str(exc)
+            failed += 1
+
+        await sync_repo.insert_sync_operation({
+            "user_id": user_id,
+            "client_id": client_id,
+            "type": op_type,
+            "payload": json.dumps(original_payload),
+            "status": status,
+            "server_id": server_id,
+        })
+
+        results.append({
+            "client_id": client_id,
+            "status": status,
+            "server_id": server_id,
+            "error": error_msg,
+        })
+
+    return {
+        "applied": applied,
+        "skipped": skipped,
+        "failed": failed,
+        "results": results,
+    }

--- a/backend/migrations/versions/005_add_sync_server_id.py
+++ b/backend/migrations/versions/005_add_sync_server_id.py
@@ -1,0 +1,30 @@
+"""add_sync_server_id
+
+Revision ID: 005
+Revises: 004
+Create Date: 2025-07-01
+
+Agrega columna server_id a sync_operations para mapear client_id → server_id
+en operaciones de sincronización offline.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "005"
+down_revision: Union[str, None] = "004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sync_operations",
+        sa.Column("server_id", sa.String(36), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("sync_operations", "server_id")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -145,6 +145,13 @@ SQLITE_LOG_COLUMNS = [
     _tm.tables["daily_logs"].c.created_at, _tm.tables["daily_logs"].c.updated_at,
 ]
 
+SQLITE_SYNC_COLUMNS = [
+    _tm.tables["sync_operations"].c.id, _tm.tables["sync_operations"].c.user_id,
+    _tm.tables["sync_operations"].c.client_id, _tm.tables["sync_operations"].c.type,
+    _tm.tables["sync_operations"].c.payload, _tm.tables["sync_operations"].c.status,
+    _tm.tables["sync_operations"].c.server_id, _tm.tables["sync_operations"].c.applied_at,
+]
+
 
 @pytest.fixture(autouse=True)
 async def sqlite_engine(monkeypatch):
@@ -156,11 +163,13 @@ async def sqlite_engine(monkeypatch):
     monkeypatch.setattr("app.repositories.cycle_repo.engine", engine)
     monkeypatch.setattr("app.repositories.daily_log_repo.engine", engine)
     monkeypatch.setattr("app.repositories.symptom_repo.engine", engine)
+    monkeypatch.setattr("app.repositories.sync_repo.engine", engine)
     monkeypatch.setattr("app.repositories.analytics_repo.engine", engine)
     monkeypatch.setattr("app.repositories.analytics_repo.cycles_table", _tm.tables["cycles"])
     monkeypatch.setattr("app.repositories.analytics_repo.daily_logs_table", _tm.tables["daily_logs"])
     monkeypatch.setattr("app.repositories.analytics_repo.daily_symptoms_table", _tm.tables["daily_symptoms"])
     monkeypatch.setattr("app.repositories.analytics_repo.symptoms_catalog_table", _tm.tables["symptoms_catalog"])
+    monkeypatch.setattr("app.repositories.sync_repo.sync_operations_table", _tm.tables["sync_operations"])
 
     monkeypatch.setattr(
         "app.repositories.cycle_repo.cycles_table", _tm.tables["cycles"]
@@ -173,6 +182,9 @@ async def sqlite_engine(monkeypatch):
     )
     monkeypatch.setattr(
         "app.repositories.daily_log_repo.LOG_COLUMNS", SQLITE_LOG_COLUMNS
+    )
+    monkeypatch.setattr(
+        "app.repositories.sync_repo.SYNC_COLUMNS", SQLITE_SYNC_COLUMNS
     )
     yield engine
     await engine.dispose()

--- a/backend/tests/test_metadata.py
+++ b/backend/tests/test_metadata.py
@@ -138,5 +138,6 @@ sync_operations_table = Table(
     Column("type", String(30), nullable=False),
     Column("payload", Text, nullable=False),
     Column("status", String(20), nullable=False, server_default=text("1")),
+    Column("server_id", String(36), nullable=True),
     Column("applied_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
 )

--- a/backend/tests/test_sync_service.py
+++ b/backend/tests/test_sync_service.py
@@ -1,0 +1,348 @@
+import json
+from datetime import date, datetime
+from unittest.mock import patch
+
+import pytest
+
+from app.services.sync_service import process_sync
+
+TEST_USER_ID = "550e8400-e29b-41d4-a716-446655440000"
+TEST_CYCLE_ID = "550e8400-e29b-41d4-a716-446655440001"
+TEST_LOG_ID = "550e8400-e29b-41d4-a716-446655440002"
+
+
+def _make_op(client_id, op_type, payload, timestamp=None):
+    return {
+        "client_id": client_id,
+        "type": op_type,
+        "payload": payload,
+        "client_timestamp": timestamp or datetime(2025, 6, 1, 8, 0, 0),
+    }
+
+
+class TestProcessSync:
+    @pytest.mark.asyncio
+    @patch("app.services.sync_service.sync_repo.find_by_client_id")
+    @patch("app.services.sync_service.sync_repo.insert_sync_operation")
+    @patch("app.services.sync_service.cycle_service.create_cycle")
+    async def test_create_cycle_applied(self, mock_create, mock_insert, mock_find):
+        mock_find.return_value = None
+        mock_create.return_value = {"id": TEST_CYCLE_ID}
+
+        result = await process_sync(
+            user_id=TEST_USER_ID,
+            operations=[
+                _make_op("op_001", "CREATE_CYCLE", {"start_date": "2025-06-01", "end_date": "2025-06-05"}),
+            ],
+        )
+
+        assert result["applied"] == 1
+        assert result["skipped"] == 0
+        assert result["failed"] == 0
+        assert result["results"][0]["client_id"] == "op_001"
+        assert result["results"][0]["status"] == "applied"
+        assert result["results"][0]["server_id"] == TEST_CYCLE_ID
+        mock_create.assert_awaited_once()
+        mock_insert.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch("app.services.sync_service.sync_repo.find_by_client_id")
+    @patch("app.services.sync_service.sync_repo.insert_sync_operation")
+    async def test_duplicate_client_id_skipped(self, mock_insert, mock_find):
+        mock_find.return_value = type("Row", (), {
+            "_mapping": {"client_id": "op_001", "server_id": TEST_CYCLE_ID, "status": "applied"},
+            "server_id": TEST_CYCLE_ID,
+        })()
+
+        result = await process_sync(
+            user_id=TEST_USER_ID,
+            operations=[
+                _make_op("op_001", "CREATE_CYCLE", {"start_date": "2025-06-01"}),
+            ],
+        )
+
+        assert result["applied"] == 0
+        assert result["skipped"] == 1
+        assert result["failed"] == 0
+        assert result["results"][0]["status"] == "skipped"
+        assert result["results"][0]["server_id"] == TEST_CYCLE_ID
+        mock_insert.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("app.services.sync_service.sync_repo.find_by_client_id")
+    @patch("app.services.sync_service.sync_repo.resolve_client_id")
+    @patch("app.services.sync_service.sync_repo.insert_sync_operation")
+    @patch("app.services.sync_service.cycle_service.create_cycle")
+    @patch("app.services.sync_service.symptom_service.create_log")
+    async def test_create_cycle_then_daily_log_cross_reference(
+        self, mock_create_log, mock_create_cycle, mock_insert, mock_resolve, mock_find
+    ):
+        mock_find.return_value = None
+        mock_create_cycle.return_value = {"id": TEST_CYCLE_ID}
+        mock_create_log.return_value = {"id": TEST_LOG_ID}
+
+        ops = [
+            _make_op("op_001", "CREATE_CYCLE", {"start_date": "2025-06-01"}, datetime(2025, 6, 1, 8, 0, 0)),
+            _make_op("op_002", "CREATE_DAILY_LOG", {
+                "cycle_client_id": "op_001",
+                "date": "2025-06-01",
+                "flow_level": "heavy",
+                "symptoms": [{"symptom_id": 1, "intensity": 4}],
+            }, datetime(2025, 6, 1, 9, 0, 0)),
+        ]
+
+        result = await process_sync(user_id=TEST_USER_ID, operations=ops)
+
+        assert result["applied"] == 2
+        assert result["skipped"] == 0
+        assert result["failed"] == 0
+        assert result["results"][0]["client_id"] == "op_001"
+        assert result["results"][0]["status"] == "applied"
+        assert result["results"][0]["server_id"] == TEST_CYCLE_ID
+        assert result["results"][1]["client_id"] == "op_002"
+        assert result["results"][1]["status"] == "applied"
+        assert result["results"][1]["server_id"] == TEST_LOG_ID
+        mock_create_cycle.assert_awaited_once()
+        mock_create_log.assert_awaited_once()
+        mock_resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("app.services.sync_service.sync_repo.find_by_client_id")
+    @patch("app.services.sync_service.sync_repo.resolve_client_id")
+    @patch("app.services.sync_service.sync_repo.insert_sync_operation")
+    @patch("app.services.sync_service.cycle_service.update_cycle")
+    async def test_update_cycle_resolves_from_table(
+        self, mock_update, mock_insert, mock_resolve, mock_find
+    ):
+        mock_find.return_value = None
+        mock_resolve.return_value = TEST_CYCLE_ID
+
+        result = await process_sync(
+            user_id=TEST_USER_ID,
+            operations=[
+                _make_op("op_003", "UPDATE_CYCLE", {
+                    "cycle_client_id": "op_001",
+                    "end_date": "2025-06-07",
+                }),
+            ],
+        )
+
+        assert result["applied"] == 1
+        assert result["results"][0]["status"] == "applied"
+        assert result["results"][0]["server_id"] == TEST_CYCLE_ID
+        mock_resolve.assert_awaited_once_with("op_001")
+        mock_update.assert_awaited_once_with(TEST_CYCLE_ID, TEST_USER_ID, {"end_date": date(2025, 6, 7)})
+
+    @pytest.mark.asyncio
+    @patch("app.services.sync_service.sync_repo.find_by_client_id")
+    @patch("app.services.sync_service.sync_repo.resolve_client_id")
+    @patch("app.services.sync_service.sync_repo.insert_sync_operation")
+    @patch("app.services.sync_service.cycle_service.delete_cycle")
+    async def test_delete_cycle(self, mock_delete, mock_insert, mock_resolve, mock_find):
+        mock_find.return_value = None
+        mock_resolve.return_value = TEST_CYCLE_ID
+
+        result = await process_sync(
+            user_id=TEST_USER_ID,
+            operations=[
+                _make_op("op_004", "DELETE_CYCLE", {"cycle_client_id": "op_001"}),
+            ],
+        )
+
+        assert result["applied"] == 1
+        mock_resolve.assert_awaited_once_with("op_001")
+        mock_delete.assert_awaited_once_with(TEST_CYCLE_ID, TEST_USER_ID)
+
+    @pytest.mark.asyncio
+    @patch("app.services.sync_service.sync_repo.find_by_client_id")
+    @patch("app.services.sync_service.sync_repo.resolve_client_id")
+    @patch("app.services.sync_service.sync_repo.insert_sync_operation")
+    @patch("app.services.sync_service.symptom_service.update_log")
+    async def test_update_daily_log(self, mock_update, mock_insert, mock_resolve, mock_find):
+        mock_find.return_value = None
+        mock_resolve.return_value = TEST_LOG_ID
+
+        result = await process_sync(
+            user_id=TEST_USER_ID,
+            operations=[
+                _make_op("op_005", "UPDATE_DAILY_LOG", {
+                    "log_client_id": "op_002",
+                    "flow_level": "light",
+                }),
+            ],
+        )
+
+        assert result["applied"] == 1
+        mock_resolve.assert_awaited_once_with("op_002")
+        mock_update.assert_awaited_once_with(TEST_LOG_ID, {"flow_level": "light"}, TEST_USER_ID)
+
+    @pytest.mark.asyncio
+    @patch("app.services.sync_service.sync_repo.find_by_client_id")
+    @patch("app.services.sync_service.sync_repo.resolve_client_id")
+    @patch("app.services.sync_service.sync_repo.insert_sync_operation")
+    @patch("app.services.sync_service.symptom_service.delete_log")
+    async def test_delete_daily_log(self, mock_delete, mock_insert, mock_resolve, mock_find):
+        mock_find.return_value = None
+        mock_resolve.return_value = TEST_LOG_ID
+
+        result = await process_sync(
+            user_id=TEST_USER_ID,
+            operations=[
+                _make_op("op_006", "DELETE_DAILY_LOG", {"log_client_id": "op_002"}),
+            ],
+        )
+
+        assert result["applied"] == 1
+        mock_resolve.assert_awaited_once_with("op_002")
+        mock_delete.assert_awaited_once_with(TEST_LOG_ID, TEST_USER_ID)
+
+    @pytest.mark.asyncio
+    @patch("app.services.sync_service.sync_repo.find_by_client_id")
+    @patch("app.services.sync_service.sync_repo.insert_sync_operation")
+    @patch("app.services.sync_service.cycle_service.create_cycle")
+    async def test_operation_failure_is_isolated(self, mock_create, mock_insert, mock_find):
+        mock_find.return_value = None
+        mock_create.side_effect = [{"id": TEST_CYCLE_ID}, Exception("DB error")]
+
+        ops = [
+            _make_op("op_001", "CREATE_CYCLE", {"start_date": "2025-06-01"}),
+            _make_op("op_002", "CREATE_CYCLE", {"start_date": "2025-06-10"}),
+        ]
+
+        result = await process_sync(user_id=TEST_USER_ID, operations=ops)
+
+        assert result["applied"] == 1
+        assert result["failed"] == 1
+        assert result["results"][0]["status"] == "applied"
+        assert result["results"][1]["status"] == "failed"
+        assert result["results"][1]["error"] == "DB error"
+        assert mock_insert.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("app.services.sync_service.sync_repo.find_by_client_id")
+    @patch("app.services.sync_service.sync_repo.insert_sync_operation")
+    @patch("app.services.sync_service.sync_repo.resolve_client_id")
+    @patch("app.services.sync_service.cycle_service.create_cycle")
+    @patch("app.services.sync_service.cycle_service.delete_cycle")
+    async def test_mixed_batch_applied_skipped_failed(
+        self, mock_delete, mock_create, mock_resolve, mock_insert, mock_find
+    ):
+        seen = set()
+
+        def _find_side(client_id):
+            if client_id in ("op_001", "op_002"):
+                return None
+            if client_id == "op_003":
+                if client_id not in seen:
+                    seen.add(client_id)
+                    return None
+                return type("Row", (), {"_mapping": {"server_id": TEST_CYCLE_ID}, "server_id": TEST_CYCLE_ID})()
+            return None
+
+        mock_find.side_effect = _find_side
+        mock_create.return_value = {"id": TEST_CYCLE_ID}
+        mock_resolve.return_value = None
+
+        ops = [
+            _make_op("op_001", "CREATE_CYCLE", {"start_date": "2025-06-01"}, datetime(2025, 6, 1, 8, 0)),
+            _make_op("op_002", "CREATE_CYCLE", {"start_date": "2025-06-10"}, datetime(2025, 6, 1, 9, 0)),
+            _make_op("op_003", "CREATE_CYCLE", {"start_date": "2025-06-20"}, datetime(2025, 6, 1, 10, 0)),
+            _make_op("op_003", "CREATE_CYCLE", {"start_date": "2025-06-20"}, datetime(2025, 6, 1, 11, 0)),
+            _make_op("op_004", "DELETE_CYCLE", {"cycle_client_id": "op_999"}, datetime(2025, 6, 1, 12, 0)),
+        ]
+
+        result = await process_sync(user_id=TEST_USER_ID, operations=ops)
+
+        assert result["applied"] == 3
+        assert result["skipped"] == 1
+        assert result["failed"] == 1
+        assert len(result["results"]) == 5
+
+    @pytest.mark.asyncio
+    @patch("app.services.sync_service.sync_repo.find_by_client_id")
+    @patch("app.services.sync_service.sync_repo.insert_sync_operation")
+    async def test_empty_batch(self, mock_insert, mock_find):
+        result = await process_sync(user_id=TEST_USER_ID, operations=[])
+        assert result["applied"] == 0
+        assert result["skipped"] == 0
+        assert result["failed"] == 0
+        assert result["results"] == []
+
+    @pytest.mark.asyncio
+    @patch("app.services.sync_service.sync_repo.find_by_client_id")
+    @patch("app.services.sync_service.sync_repo.resolve_client_id")
+    @patch("app.services.sync_service.sync_repo.insert_sync_operation")
+    @patch("app.services.sync_service.cycle_service.create_cycle")
+    @patch("app.services.sync_service.cycle_service.delete_cycle")
+    async def test_create_then_delete_same_batch(
+        self, mock_delete, mock_create, mock_insert, mock_resolve, mock_find
+    ):
+        mock_find.return_value = None
+        mock_create.return_value = {"id": TEST_CYCLE_ID}
+
+        ops = [
+            _make_op("op_001", "CREATE_CYCLE", {"start_date": "2025-06-01"}, datetime(2025, 6, 1, 8, 0)),
+            _make_op("op_002", "DELETE_CYCLE", {"cycle_client_id": "op_001"}, datetime(2025, 6, 1, 9, 0)),
+        ]
+
+        result = await process_sync(user_id=TEST_USER_ID, operations=ops)
+
+        assert result["applied"] == 2
+        assert result["results"][0]["status"] == "applied"
+        assert result["results"][1]["status"] == "applied"
+        mock_create.assert_awaited_once()
+        mock_delete.assert_awaited_once_with(TEST_CYCLE_ID, TEST_USER_ID)
+        mock_resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("app.services.sync_service.sync_repo.find_by_client_id")
+    @patch("app.services.sync_service.sync_repo.resolve_client_id")
+    @patch("app.services.sync_service.sync_repo.insert_sync_operation")
+    async def test_unresolved_client_id_fails(self, mock_insert, mock_resolve, mock_find):
+        mock_find.return_value = None
+        mock_resolve.return_value = None
+
+        result = await process_sync(
+            user_id=TEST_USER_ID,
+            operations=[
+                _make_op("op_003", "UPDATE_CYCLE", {
+                    "cycle_client_id": "op_unknown",
+                    "end_date": "2025-06-07",
+                }),
+            ],
+        )
+
+        assert result["failed"] == 1
+        assert result["results"][0]["status"] == "failed"
+        assert "No se encontró server_id" in result["results"][0]["error"]
+
+    @pytest.mark.asyncio
+    @patch("app.services.sync_service.sync_repo.find_by_client_id")
+    @patch("app.services.sync_service.sync_repo.insert_sync_operation")
+    @patch("app.services.sync_service.symptom_service.create_log")
+    @patch("app.services.sync_service.cycle_service.create_cycle")
+    async def test_create_daily_log_with_date_conversion(
+        self, mock_create, mock_create_log, mock_insert, mock_find
+    ):
+        mock_find.return_value = None
+        mock_create.return_value = {"id": TEST_CYCLE_ID}
+        mock_create_log.return_value = {"id": TEST_LOG_ID}
+
+        ops = [
+            _make_op("op_001", "CREATE_CYCLE", {"start_date": "2025-06-01"}, datetime(2025, 6, 1, 8, 0, 0)),
+            _make_op("op_002", "CREATE_DAILY_LOG", {
+                "cycle_client_id": "op_001",
+                "date": "2025-06-01",
+                "temperature": 36.5,
+                "symptoms": [{"symptom_id": 1, "intensity": 3}],
+            }, datetime(2025, 6, 1, 9, 0, 0)),
+        ]
+
+        result = await process_sync(user_id=TEST_USER_ID, operations=ops)
+
+        assert result["applied"] == 2
+        called_data = mock_create_log.call_args[0][0]
+        assert isinstance(called_data["date"], date)
+        assert called_data["date"] == date(2025, 6, 1)
+        assert called_data["temperature"] == 36.5
+        assert called_data["symptoms"] == [{"symptom_id": 1, "intensity": 3}]


### PR DESCRIPTION
## Issue
Closes #39

## Qué hace
Implementa el endpoint `POST /sync` que recibe un batch de operaciones
offline desde el frontend y las aplica de forma idempotente.

## Tipos de operación soportados
- CREATE_CYCLE / UPDATE_CYCLE / DELETE_CYCLE
- CREATE_DAILY_LOG / UPDATE_DAILY_LOG / DELETE_DAILY_LOG

## Cambios principales

| Archivo | Tipo | Propósito |
|---------|------|-----------|
| `app/models/sync.py` | Nuevo | Pydantic schemas |
| `app/repositories/sync_repo.py` | Nuevo | CRUD sobre sync_operations |
| `app/services/sync_service.py` | Nuevo | Orquestador del batch |
| `app/routers/sync.py` | Nuevo | POST /sync |
| `app/main.py` | Modif. | Registrar router |
| `app/models/db_tables.py` | Modif. | Columna server_id |
| `migrations/.../005_*.py` | Nuevo | Migración server_id |
| `tests/test_sync_service.py` | Nuevo | 13 tests unitarios |

## Diseño
- Idempotencia: cada `client_id` se procesa una sola vez
- Resolución cross-operación: `cycle_client_id` → server UUID usando batch map + tabla
- Errores aislados: una operación fallida no interrumpe el batch
- Reutiliza `cycle_service` y `symptom_service` para validar ownership

## Tests
13 tests unitarios (mock), 100 total pasando.