### PR TITLE
[S5] feat: integrar Ollama para insights conversacionales (Issue #32)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
-from app.routers import health, cycles, symptoms, analytics, predictions, sync
+from app.routers import health, cycles, symptoms, analytics, predictions, sync, insights
 
 app = FastAPI(
     title="EVA API",
@@ -33,3 +33,4 @@ app.include_router(symptoms.daily_logs_router)
 app.include_router(analytics.router)
 app.include_router(predictions.router)
 app.include_router(sync.router)
+app.include_router(insights.router)

--- a/backend/app/models/insight.py
+++ b/backend/app/models/insight.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class InsightRequest(BaseModel):
+    question: str = Field(..., min_length=1, description="Pregunta de la usuaria sobre su ciclo")
+    context_cycles: int = Field(default=3, ge=1, le=12, description="Cantidad de ciclos a considerar para el contexto")
+
+
+class InsightResponse(BaseModel):
+    insight: str
+    phase: Optional[str] = None
+    source: str
+    disclaimer: str = "EVA no reemplaza el consejo médico profesional."
+
+
+class InsightHistoryItem(BaseModel):
+    id: str
+    question: str
+    insight: str
+    phase: Optional[str] = None
+    source: str
+    created_at: datetime
+
+
+class InsightHistoryResponse(BaseModel):
+    total: int
+    limit: int
+    offset: int
+    insights: list[InsightHistoryItem]

--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -32,6 +32,11 @@ from app.repositories.sync_repo import (
     resolve_client_id,
 )
 
+from app.repositories.insight_repo import (
+    save_insight,
+    get_insights_history,
+)
+
 __all__ = [
     "get_cycles_by_user",
     "get_cycle_by_id",
@@ -57,4 +62,6 @@ __all__ = [
     "find_by_client_id",
     "insert_sync_operation",
     "resolve_client_id",
+    "save_insight",
+    "get_insights_history",
 ]

--- a/backend/app/repositories/insight_repo.py
+++ b/backend/app/repositories/insight_repo.py
@@ -1,0 +1,65 @@
+from typing import Optional
+
+from sqlalchemy import insert, select, func
+
+from app.core.db import engine
+from app.models.db_tables import llm_insights_table
+
+INSIGHT_COLUMNS = [
+    llm_insights_table.c.id,
+    llm_insights_table.c.user_id,
+    llm_insights_table.c.question,
+    llm_insights_table.c.insight,
+    llm_insights_table.c.phase,
+    llm_insights_table.c.source,
+    llm_insights_table.c.created_at,
+]
+
+
+async def save_insight(
+    user_id: str,
+    question: str,
+    insight: str,
+    phase: Optional[str],
+    source: str,
+) -> dict:
+    query = (
+        insert(llm_insights_table)
+        .values(
+            user_id=user_id,
+            question=question,
+            insight=insight,
+            phase=phase,
+            source=source,
+        )
+        .returning(*INSIGHT_COLUMNS)
+    )
+    async with engine.connect() as conn:
+        result = await conn.execute(query)
+        await conn.commit()
+        row = result.one()
+        return dict(row._mapping)
+
+
+async def get_insights_history(
+    user_id: str,
+    limit: int = 20,
+    offset: int = 0,
+) -> tuple[int, list]:
+    count_query = (
+        select(func.count())
+        .select_from(llm_insights_table)
+        .where(llm_insights_table.c.user_id == user_id)
+    )
+    select_query = (
+        select(*INSIGHT_COLUMNS)
+        .where(llm_insights_table.c.user_id == user_id)
+        .order_by(llm_insights_table.c.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    async with engine.connect() as conn:
+        total = await conn.execute(count_query)
+        total_count = total.scalar_one()
+        rows = await conn.execute(select_query)
+        return total_count, rows.fetchall()

--- a/backend/app/routers/insights.py
+++ b/backend/app/routers/insights.py
@@ -1,0 +1,87 @@
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.core.security import get_current_user
+from app.models.insight import (
+    InsightRequest,
+    InsightResponse,
+    InsightHistoryResponse,
+    InsightHistoryItem,
+)
+from app.repositories import insight_repo
+from app.services import llm_service
+
+router = APIRouter(prefix="/insights", tags=["insights"])
+
+
+@router.post("", response_model=InsightResponse)
+async def create_insight(
+    body: InsightRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    user_id: str = current_user["user_id"]
+
+    cycle_context = await llm_service.build_cycle_context(
+        user_id=user_id,
+        context_cycles=body.context_cycles,
+    )
+
+    try:
+        result = await llm_service.get_insight(
+            question=body.question,
+            cycle_context=cycle_context,
+        )
+    except RuntimeError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="AI service temporarily unavailable. Please try again later.",
+        )
+
+    await insight_repo.save_insight(
+        user_id=user_id,
+        question=body.question,
+        insight=result["insight"],
+        phase=cycle_context.get("fase_actual"),
+        source=result["source"],
+    )
+
+    return InsightResponse(
+        insight=result["insight"],
+        phase=cycle_context.get("fase_actual"),
+        source=result["source"],
+        disclaimer=result["disclaimer"],
+    )
+
+
+@router.get("/history", response_model=InsightHistoryResponse)
+async def list_insights_history(
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    current_user: dict = Depends(get_current_user),
+):
+    user_id: str = current_user["user_id"]
+    total, rows = await insight_repo.get_insights_history(
+        user_id=user_id,
+        limit=limit,
+        offset=offset,
+    )
+
+    insights = []
+    for row in rows:
+        data = dict(row._mapping)
+        insights.append(
+            InsightHistoryItem(
+                id=str(data["id"]),
+                question=data["question"],
+                insight=data["insight"],
+                phase=data.get("phase"),
+                source=data["source"],
+                created_at=data["created_at"],
+            )
+        )
+
+    return InsightHistoryResponse(
+        total=total,
+        limit=limit,
+        offset=offset,
+        insights=insights,
+    )

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,4 +1,4 @@
-from app.services import cycle_service, symptom_service, analytics_service, prediction_service, sync_service
+from app.services import cycle_service, symptom_service, analytics_service, prediction_service, sync_service, llm_service
 
 __all__ = [
     "cycle_service",
@@ -6,4 +6,5 @@ __all__ = [
     "analytics_service",
     "prediction_service",
     "sync_service",
+    "llm_service",
 ]

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -1,0 +1,152 @@
+from datetime import date, timedelta
+from typing import Optional
+
+import httpx
+
+from app.core.config import settings
+from app.repositories import cycle_repo
+from app.utils.cycle_utils import calculate_current_phase
+
+OLLAMA_BASE_URL = settings.OLLAMA_BASE_URL
+OLLAMA_MODEL = "mistral"
+
+GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions"
+GROQ_MODEL = "llama3-8b-8192"
+
+SYSTEM_PROMPT = """
+Eres EVA, una asistente de salud menstrual. Respondes en espanol, con tono calido,
+empatico y basado en evidencia cientifica. Tus respuestas son concisas (maximo 4 oraciones)
+y siempre incluyen el disclaimer de que no reemplazas al medico.
+
+Principios:
+- Solo hablas de salud menstrual y temas relacionados
+- Nunca haces diagnosticos medicos
+- Si la usuaria menciona sintomas graves, la remites a su ginecologa
+- Usas los datos del ciclo proporcionados para personalizar la respuesta
+"""
+
+
+def build_context_prompt(cycle_context: dict, question: str) -> str:
+    sintomas = ", ".join(cycle_context.get("sintomas_frecuentes", []))
+    return f"""
+Contexto del ciclo actual:
+- Fase: {cycle_context.get('fase_actual', 'desconocida')}
+- Dia del ciclo: {cycle_context.get('dia_del_ciclo', '?')}
+- Duracion promedio de sus ciclos: {cycle_context.get('duracion_promedio', 28)} dias
+- Sintomas mas frecuentes: {sintomas if sintomas else 'ninguno registrado'}
+- Intensidad de sintomas actual: {cycle_context.get('intensidad_actual', 'moderada')}
+- Dias hasta el proximo periodo: {cycle_context.get('dias_hasta_siguiente', '?')}
+
+Pregunta: {question}
+"""
+
+
+async def _call_ollama(prompt: str) -> Optional[str]:
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                f"{OLLAMA_BASE_URL}/api/generate",
+                json={
+                    "model": OLLAMA_MODEL,
+                    "prompt": f"{SYSTEM_PROMPT}\n\n{prompt}",
+                    "stream": False,
+                    "options": {"temperature": 0.7, "num_predict": 300},
+                },
+            )
+            response.raise_for_status()
+            return response.json()["response"].strip()
+    except Exception:
+        return None
+
+
+async def _call_groq(prompt: str) -> Optional[str]:
+    if not settings.GROQ_API_KEY:
+        return None
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                GROQ_API_URL,
+                headers={"Authorization": f"Bearer {settings.GROQ_API_KEY}"},
+                json={
+                    "model": GROQ_MODEL,
+                    "messages": [
+                        {"role": "system", "content": SYSTEM_PROMPT},
+                        {"role": "user", "content": prompt},
+                    ],
+                    "max_tokens": 300,
+                    "temperature": 0.7,
+                },
+            )
+            response.raise_for_status()
+            return response.json()["choices"][0]["message"]["content"].strip()
+    except Exception:
+        return None
+
+
+async def build_cycle_context(user_id: str, context_cycles: int = 3) -> dict:
+    rows = await cycle_repo.get_cycles_by_user(user_id, limit=context_cycles, offset=0)
+
+    if not rows:
+        return {
+            "fase_actual": None,
+            "dia_del_ciclo": None,
+            "duracion_promedio": 28,
+            "sintomas_frecuentes": [],
+            "intensidad_actual": "moderada",
+            "dias_hasta_siguiente": None,
+        }
+
+    cycles = [dict(row._mapping) for row in rows]
+    cycles.sort(key=lambda c: c["start_date"])
+
+    last_cycle = cycles[-1]
+    last_cycle_dict = {
+        "start_date": last_cycle["start_date"],
+        "end_date": last_cycle.get("end_date"),
+    }
+
+    phase, phase_day = calculate_current_phase(last_cycle_dict)
+
+    if len(cycles) == 1:
+        avg_duration = 28.0
+    else:
+        durations = [
+            (cycles[i]["start_date"] - cycles[i - 1]["start_date"]).days
+            for i in range(1, len(cycles))
+        ]
+        avg_duration = round(sum(durations) / len(durations), 1)
+
+    predicted_next = last_cycle["start_date"] + timedelta(days=int(round(avg_duration)))
+    days_until_next = (predicted_next - date.today()).days if predicted_next > date.today() else 0
+
+    return {
+        "fase_actual": phase,
+        "dia_del_ciclo": phase_day,
+        "duracion_promedio": avg_duration,
+        "sintomas_frecuentes": [],
+        "intensidad_actual": "moderada",
+        "dias_hasta_siguiente": days_until_next,
+    }
+
+
+async def get_insight(question: str, cycle_context: dict) -> dict:
+    prompt = build_context_prompt(cycle_context, question)
+
+    ollama_response = await _call_ollama(prompt)
+    if ollama_response:
+        return {
+            "insight": ollama_response,
+            "source": f"ollama/{OLLAMA_MODEL}",
+            "disclaimer": "EVA no reemplaza el consejo medico profesional.",
+        }
+
+    groq_response = await _call_groq(prompt)
+    if groq_response:
+        return {
+            "insight": groq_response,
+            "source": f"groq/{GROQ_MODEL}",
+            "disclaimer": "EVA no reemplaza el consejo medico profesional.",
+        }
+
+    raise RuntimeError("LLM service unavailable")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -45,6 +45,7 @@ narwhals==2.22.1
 joblib==1.5.3
 
 # ── Utilidades ───────────────────────────────────────────────
+httpx==0.28.1
 python-dotenv==1.2.2
 PyYAML==6.0.3
 idna==3.14


### PR DESCRIPTION
## Issue #32 - Integrar Ollama para insights conversacionales

### Cambios incluidos

**Nuevos archivos:**
- `backend/app/models/insight.py` - Schemas Pydantic (InsightRequest, InsightResponse, InsightHistoryResponse)
- `backend/app/repositories/insight_repo.py` - CRUD para tabla llm_insights
- `backend/app/services/llm_service.py` - Core LLM con Ollama + fallback Groq
- `backend/app/routers/insights.py` - POST /insights y GET /insights/history

**Archivos modificados:**
- `backend/app/repositories/__init__.py` - Registro de insight_repo
- `backend/app/services/__init__.py` - Registro de llm_service
- `backend/app/main.py` - Registro de insights router
- `backend/requirements.txt` - Agregado httpx

### Arquitectura del LLM
```
POST /insights
  ? build_cycle_context() (sin PII)
  ? get_insight() ? Ollama (local) ? Groq (fallback) ? 503
  ? save_insight() en BD
```

### Criterios cumplidos
- [x] ollama_service con _call_ollama() timeout 30s
- [x] _call_groq() como fallback con GROQ_API_KEY
- [x] Sistema de fallback: Ollama ? Groq ? 503
- [x] Contexto sin email, nombre ni birth_date
- [x] POST /insights funcionando
- [x] Respuestas en espanol (system prompt configurado)