### PR TITLE
[S7] LLM con datos reales del ciclo + tests (Issue #43)

### DIFF
--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -4,7 +4,7 @@ from typing import Optional
 import httpx
 
 from app.core.config import settings
-from app.repositories import cycle_repo
+from app.repositories import analytics_repo, cycle_repo, daily_log_repo, symptom_repo
 from app.utils.cycle_utils import calculate_current_phase
 
 OLLAMA_BASE_URL = settings.OLLAMA_BASE_URL
@@ -84,7 +84,7 @@ async def _call_groq(prompt: str) -> Optional[str]:
         return None
 
 
-async def build_cycle_context(user_id: str, context_cycles: int = 3) -> dict:
+async def build_cycle_context(user_id: str, context_cycles: int = 6) -> dict:
     rows = await cycle_repo.get_cycles_by_user(user_id, limit=context_cycles, offset=0)
 
     if not rows:
@@ -93,7 +93,7 @@ async def build_cycle_context(user_id: str, context_cycles: int = 3) -> dict:
             "dia_del_ciclo": None,
             "duracion_promedio": 28,
             "sintomas_frecuentes": [],
-            "intensidad_actual": "moderada",
+            "intensidad_actual": None,
             "dias_hasta_siguiente": None,
         }
 
@@ -120,12 +120,33 @@ async def build_cycle_context(user_id: str, context_cycles: int = 3) -> dict:
     predicted_next = last_cycle["start_date"] + timedelta(days=int(round(avg_duration)))
     days_until_next = (predicted_next - date.today()).days if predicted_next > date.today() else 0
 
+    # ── Síntomas frecuentes desde la BD ───────────────────────────
+    cycle_ids = [c["id"] for c in cycles]
+    symptom_rows = await analytics_repo.get_symptom_frequencies(cycle_ids, limit=5)
+
+    sintomas_frecuentes = []
+    intensidad_actual = None
+    if symptom_rows:
+        sintomas_frecuentes = [s["name"] for s in symptom_rows]
+        intensidad_actual = str(symptom_rows[0]["avg_intensity"])
+
+    # ── Intensidad del día de hoy desde daily_logs ────────────────
+    today = date.today()
+    log = await daily_log_repo.get_daily_log_by_date(last_cycle["id"], today)
+    if log:
+        log_id = str(log._mapping["id"])
+        today_symptoms = await symptom_repo.get_symptoms_by_log(log_id)
+        if today_symptoms:
+            intensities = [s["intensity"] for s in today_symptoms]
+            avg_today = round(sum(intensities) / len(intensities), 1)
+            intensidad_actual = str(avg_today)
+
     return {
         "fase_actual": phase,
         "dia_del_ciclo": phase_day,
         "duracion_promedio": avg_duration,
-        "sintomas_frecuentes": [],
-        "intensidad_actual": "moderada",
+        "sintomas_frecuentes": sintomas_frecuentes,
+        "intensidad_actual": intensidad_actual or "moderada",
         "dias_hasta_siguiente": days_until_next,
     }
 

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -1,0 +1,119 @@
+from datetime import date, timedelta
+
+import pytest
+from sqlalchemy import insert
+
+from app.services.llm_service import build_cycle_context, build_context_prompt
+from tests.conftest import SEED_SYMPTOMS, TEST_USER_ID
+from tests.test_metadata import (
+    cycles_table as test_cycles,
+    daily_logs_table as test_logs,
+    daily_symptoms_table as test_daily_symptoms,
+    symptoms_catalog_table as test_catalog,
+)
+
+CYCLE_1_ID = "c0000000-e29b-41d4-a716-446655440001"
+CYCLE_2_ID = "c0000000-e29b-41d4-a716-446655440002"
+CYCLE_3_ID = "c0000000-e29b-41d4-a716-446655440003"
+LOG_1_ID = "c0000000-e29b-41d4-a716-446655440010"
+
+
+@pytest.fixture
+async def seeded_cycles(sqlite_engine):
+    async with sqlite_engine.begin() as conn:
+        await conn.execute(insert(test_catalog).values(SEED_SYMPTOMS))
+        await conn.execute(
+            insert(test_cycles).values(
+                id=CYCLE_1_ID,
+                user_id=TEST_USER_ID,
+                start_date=date(2025, 5, 1),
+                end_date=date(2025, 5, 5),
+            )
+        )
+        await conn.execute(
+            insert(test_cycles).values(
+                id=CYCLE_2_ID,
+                user_id=TEST_USER_ID,
+                start_date=date(2025, 5, 29),
+                end_date=date(2025, 6, 2),
+            )
+        )
+        await conn.execute(
+            insert(test_cycles).values(
+                id=CYCLE_3_ID,
+                user_id=TEST_USER_ID,
+                start_date=date(2025, 6, 26),
+                end_date=date(2025, 6, 30),
+            )
+        )
+        await conn.execute(
+            insert(test_logs).values(
+                id=LOG_1_ID,
+                cycle_id=CYCLE_1_ID,
+                date=date(2025, 5, 1),
+                flow_level="medium",
+            )
+        )
+        await conn.execute(
+            insert(test_daily_symptoms).values(
+                log_id=LOG_1_ID,
+                symptom_id=1,
+                intensity=3,
+            )
+        )
+
+
+class TestBuildCycleContext:
+    async def test_no_cycles_returns_defaults(self):
+        ctx = await build_cycle_context(TEST_USER_ID)
+        assert ctx["fase_actual"] is None
+        assert ctx["sintomas_frecuentes"] == []
+        assert ctx["duracion_promedio"] == 28
+
+    async def test_returns_phase_and_symptoms(self, seeded_cycles):
+        ctx = await build_cycle_context(TEST_USER_ID, context_cycles=3)
+        assert ctx["fase_actual"] is not None
+        assert ctx["duracion_promedio"] == 28.0
+        assert ctx["sintomas_frecuentes"] != []
+        assert isinstance(ctx["sintomas_frecuentes"], list)
+        assert ctx["intensidad_actual"] is not None
+
+    async def test_frequent_symptoms_from_db(self, seeded_cycles):
+        ctx = await build_cycle_context(TEST_USER_ID, context_cycles=3)
+        symptoms = ctx["sintomas_frecuentes"]
+        assert any("Dolor" in s for s in symptoms)
+
+    async def test_no_pii_in_context(self, seeded_cycles):
+        ctx = await build_cycle_context(TEST_USER_ID, context_cycles=3)
+        ctx_str = str(ctx)
+        assert TEST_USER_ID not in ctx_str
+        assert "@" not in ctx_str
+
+
+class TestBuildContextPrompt:
+    def test_includes_question_and_context(self):
+        ctx = {
+            "fase_actual": "lutea",
+            "dia_del_ciclo": 22,
+            "duracion_promedio": 28,
+            "sintomas_frecuentes": ["fatiga", "irritabilidad"],
+            "intensidad_actual": "3.5",
+            "dias_hasta_siguiente": 5,
+        }
+        prompt = build_context_prompt(ctx, "¿Por qué estoy tan cansada?")
+        assert "¿Por qué estoy tan cansada?" in prompt
+        assert "lutea" in prompt
+        assert "fatiga" in prompt
+        assert "irritabilidad" in prompt
+
+    def test_empty_symptoms_still_works(self):
+        ctx = {
+            "fase_actual": None,
+            "dia_del_ciclo": None,
+            "duracion_promedio": 28,
+            "sintomas_frecuentes": [],
+            "intensidad_actual": None,
+            "dias_hasta_siguiente": None,
+        }
+        prompt = build_context_prompt(ctx, "Hola")
+        assert "ninguno registrado" in prompt


### PR DESCRIPTION
## Issue #43 — Integrar LLM con datos reales del ciclo

### Cambios en backend/app/services/llm_service.py
- build_cycle_context ahora consulta síntomas reales desde la BD vía analytics_repo.get_symptom_frequencies
- Intensidad actual se obtiene de daily_logs del día de hoy (si existe)
- sintomas_frecuentes ya no es hardcoded vacío — trae top 5 síntomas con más ocurrencias
- PII nunca incluida en el contexto (no hay email, nombre, user_id ni IP)
- context_cycles default subió de 3 a 6 para mejor precisión

### Tests nuevos (backend/tests/test_llm_service.py) — 6 tests
- test_no_cycles_returns_defaults: 0 ciclos → valores por defecto, sin error
- test_returns_phase_and_symptoms: ciclos con síntomas → fase y síntomas presentes
- test_frequent_symptoms_from_db: síntomas frecuentes vienen de la BD
- test_no_pii_in_context: contexto no contiene user_id ni email
- test_includes_question_and_context: prompt incluye contexto y pregunta
- test_empty_symptoms_still_works: síntomas vacíos muestra ninguno registrado

### Verificación
- 109 tests pasan (6 nuevos + 103 existentes)