### PR TITLE
[S10] fix: validar cycle_id UUID en todos los endpoints

### DIFF
--- a/Docs/ISSUES.md
+++ b/Docs/ISSUES.md
@@ -353,9 +353,9 @@ PWA de salud menstrual privacy-first · React + FastAPI + ML
 
 | Estado | Cantidad | Issues |
 |--------|----------|--------|
-| ✅ Implementado | 6 | #68, #69, #70, #71, #72, #75 |
+| ✅ Implementado | 7 | #64, #68, #69, #70, #71, #72, #75 |
 | 🔧 Pendiente Daniel | 3 | #63, #66, #74 (verificar) |
-| 🔧 Pendiente Meriyei | 1 | #64 |
+| 🔧 Pendiente Meriyei | 0 | — |
 | 🔧 Pendiente Madeleine | 3 | #65, #67, #73 (verificar) |
 | 🔧 Pendiente Joshua | 5 | #76, #77, #78, #79, #80 |
 

--- a/Docs/contextoopencode.md
+++ b/Docs/contextoopencode.md
@@ -280,7 +280,7 @@ Puertos 5173/tcp y 8000/tcp abiertos vía `ufw` para acceso desde red local.
 
 | # | Título | Archivos |
 |---|--------|----------|
-| 64 | Validar `cycle_id` UUID antes de query en `list_logs_by_cycle` | `services/symptom_service.py`, `routers/symptoms.py` |
+| — | (ninguno pendiente) | #64 implementado |
 
 ### 6.3 — Pendiente Madeleine
 

--- a/backend/app/core/validators.py
+++ b/backend/app/core/validators.py
@@ -1,0 +1,18 @@
+import uuid
+
+from fastapi import HTTPException, status
+
+
+def validate_uuid_or_400(value: str, field_name: str = "id") -> None:
+    if value is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid {field_name} format",
+        )
+    try:
+        uuid.UUID(value)
+    except (ValueError, AttributeError, TypeError):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid {field_name} format",
+        )

--- a/backend/app/routers/cycles.py
+++ b/backend/app/routers/cycles.py
@@ -4,6 +4,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, Query, status
 
 from app.core.security import get_current_user
+from app.core.validators import validate_uuid_or_400
 from app.models.cycle import CycleCreate, CycleUpdate, CycleResponse, CycleListResponse
 from app.services import cycle_service
 
@@ -42,6 +43,7 @@ async def get_cycle(
     cycle_id: str,
     current_user: dict = Depends(get_current_user),
 ):
+    validate_uuid_or_400(cycle_id, "cycle_id")
     return await cycle_service.get_cycle_by_id(
         cycle_id=cycle_id,
         user_id=current_user["user_id"],
@@ -54,6 +56,7 @@ async def update_cycle(
     body: CycleUpdate,
     current_user: dict = Depends(get_current_user),
 ):
+    validate_uuid_or_400(cycle_id, "cycle_id")
     return await cycle_service.update_cycle(
         cycle_id=cycle_id,
         user_id=current_user["user_id"],
@@ -66,6 +69,7 @@ async def delete_cycle(
     cycle_id: str,
     current_user: dict = Depends(get_current_user),
 ):
+    validate_uuid_or_400(cycle_id, "cycle_id")
     await cycle_service.delete_cycle(
         cycle_id=cycle_id,
         user_id=current_user["user_id"],

--- a/backend/app/routers/symptoms.py
+++ b/backend/app/routers/symptoms.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Query, status
 
 from app.core.security import get_current_user
+from app.core.validators import validate_uuid_or_400
 from app.models.symptom import (
     SymptomResponse,
     DailyLogCreate,
@@ -30,6 +31,7 @@ async def create_daily_log(
     body: DailyLogCreate,
     current_user: dict = Depends(get_current_user),
 ):
+    validate_uuid_or_400(body.cycle_id, "cycle_id")
     return await symptom_service.create_log(
         data=body.model_dump(exclude_none=True),
         user_id=current_user["user_id"],
@@ -43,6 +45,7 @@ async def list_daily_logs(
     offset: int = Query(0, ge=0),
     current_user: dict = Depends(get_current_user),
 ):
+    validate_uuid_or_400(cycle_id, "cycle_id")
     total, logs = await symptom_service.list_logs_by_cycle(
         cycle_id=cycle_id,
         user_id=current_user["user_id"],

--- a/backend/app/services/cycle_service.py
+++ b/backend/app/services/cycle_service.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from fastapi import HTTPException, status
 
+from app.core.validators import validate_uuid_or_400
 from app.repositories import cycle_repo
 from app.repositories.daily_log_repo import get_logs_by_cycle
 
@@ -47,6 +48,7 @@ async def get_cycles_by_user(
 
 
 async def get_cycle_by_id(cycle_id: str, user_id: str) -> dict:
+    validate_uuid_or_400(cycle_id, "cycle_id")
     row = await cycle_repo.get_cycle_by_id(cycle_id, user_id)
     if not row:
         raise HTTPException(
@@ -60,6 +62,7 @@ async def get_cycle_by_id(cycle_id: str, user_id: str) -> dict:
 
 
 async def update_cycle(cycle_id: str, user_id: str, data: dict) -> dict:
+    validate_uuid_or_400(cycle_id, "cycle_id")
     if "start_date" in data:
         existing = await cycle_repo.get_cycle_by_start_date(user_id, data["start_date"])
         if existing and str(existing.id) != cycle_id:
@@ -77,6 +80,7 @@ async def update_cycle(cycle_id: str, user_id: str, data: dict) -> dict:
 
 
 async def delete_cycle(cycle_id: str, user_id: str) -> None:
+    validate_uuid_or_400(cycle_id, "cycle_id")
     deleted = await cycle_repo.delete_cycle(cycle_id, user_id)
     if not deleted:
         raise HTTPException(

--- a/backend/app/services/symptom_service.py
+++ b/backend/app/services/symptom_service.py
@@ -2,6 +2,7 @@ from datetime import date
 
 from fastapi import HTTPException, status
 
+from app.core.validators import validate_uuid_or_400
 from app.repositories import cycle_repo
 from app.repositories.daily_log_repo import (
     create_daily_log as repo_create_log,
@@ -43,6 +44,7 @@ async def get_symptom(symptom_id: int) -> dict:
 
 
 async def create_log(data: dict, user_id: str) -> dict:
+    validate_uuid_or_400(data["cycle_id"], "cycle_id")
     cycle = await cycle_repo.get_cycle_by_id(data["cycle_id"], user_id)
     if not cycle:
         raise HTTPException(
@@ -68,6 +70,7 @@ async def create_log(data: dict, user_id: str) -> dict:
 async def list_logs_by_cycle(
     cycle_id: str, user_id: str, limit: int = 50, offset: int = 0
 ) -> tuple[int, list[dict]]:
+    validate_uuid_or_400(cycle_id, "cycle_id")
     cycle = await cycle_repo.get_cycle_by_id(cycle_id, user_id)
     if not cycle:
         raise HTTPException(

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -58,6 +58,6 @@ fpdf2==2.8.1
 slowapi==0.1.9
 
 # ── Sentry ───────────────────────────────────────────────────
-sentinel-sdk==2.28.0
+sentry-sdk==2.28.0
 greenlet>=3.0
 jinja2>=3.1

--- a/backend/tests/test_cycle_service.py
+++ b/backend/tests/test_cycle_service.py
@@ -135,6 +135,20 @@ class TestGetCyclesByUser:
 
 class TestGetCycleById:
     @patch("app.services.cycle_service.cycle_repo.get_cycle_by_id")
+    async def test_invalid_uuid_returns_400(self, mock_get):
+        with pytest.raises(HTTPException) as exc:
+            await get_cycle_by_id("bad-uuid", TEST_USER_ID)
+        assert exc.value.status_code == 400
+        mock_get.assert_not_awaited()
+
+    @patch("app.services.cycle_service.cycle_repo.get_cycle_by_id")
+    async def test_empty_uuid_returns_400(self, mock_get):
+        with pytest.raises(HTTPException) as exc:
+            await get_cycle_by_id("", TEST_USER_ID)
+        assert exc.value.status_code == 400
+        mock_get.assert_not_awaited()
+
+    @patch("app.services.cycle_service.cycle_repo.get_cycle_by_id")
     @patch("app.services.cycle_service.get_logs_by_cycle")
     async def test_found(self, mock_logs, mock_get):
         mock_get.return_value = _make_cycle_row()
@@ -160,7 +174,7 @@ class TestGetCycleById:
         mock_get.return_value = None
 
         with pytest.raises(HTTPException) as exc:
-            await get_cycle_by_id("nonexistent", TEST_USER_ID)
+            await get_cycle_by_id("550e8400-e29b-41d4-a716-4466554400ff", TEST_USER_ID)
         assert exc.value.status_code == 404
 
     @patch("app.services.cycle_service.cycle_repo.get_cycle_by_id")
@@ -173,6 +187,28 @@ class TestGetCycleById:
 
 
 class TestUpdateCycle:
+    @patch("app.services.cycle_service.cycle_repo.update_cycle")
+    async def test_invalid_uuid_returns_400(self, mock_update):
+        with pytest.raises(HTTPException) as exc:
+            await update_cycle(
+                cycle_id="bad-uuid",
+                user_id=TEST_USER_ID,
+                data={"end_date": date(2025, 6, 7)},
+            )
+        assert exc.value.status_code == 400
+        mock_update.assert_not_awaited()
+
+    @patch("app.services.cycle_service.cycle_repo.update_cycle")
+    async def test_empty_uuid_returns_400(self, mock_update):
+        with pytest.raises(HTTPException) as exc:
+            await update_cycle(
+                cycle_id="",
+                user_id=TEST_USER_ID,
+                data={"end_date": date(2025, 6, 7)},
+            )
+        assert exc.value.status_code == 400
+        mock_update.assert_not_awaited()
+
     @patch("app.services.cycle_service.cycle_repo.update_cycle")
     async def test_update_valid(self, mock_update):
         mock_update.return_value = _make_cycle_row(end_date=date(2025, 6, 7))
@@ -190,7 +226,7 @@ class TestUpdateCycle:
 
         with pytest.raises(HTTPException) as exc:
             await update_cycle(
-                cycle_id="nonexistent",
+                cycle_id="550e8400-e29b-41d4-a716-4466554400ff",
                 user_id=TEST_USER_ID,
                 data={"end_date": date(2025, 6, 5)},
             )
@@ -238,6 +274,20 @@ class TestUpdateCycle:
 
 class TestDeleteCycle:
     @patch("app.services.cycle_service.cycle_repo.delete_cycle")
+    async def test_invalid_uuid_returns_400(self, mock_delete):
+        with pytest.raises(HTTPException) as exc:
+            await delete_cycle("bad-uuid", TEST_USER_ID)
+        assert exc.value.status_code == 400
+        mock_delete.assert_not_awaited()
+
+    @patch("app.services.cycle_service.cycle_repo.delete_cycle")
+    async def test_empty_uuid_returns_400(self, mock_delete):
+        with pytest.raises(HTTPException) as exc:
+            await delete_cycle("", TEST_USER_ID)
+        assert exc.value.status_code == 400
+        mock_delete.assert_not_awaited()
+
+    @patch("app.services.cycle_service.cycle_repo.delete_cycle")
     async def test_delete_success(self, mock_delete):
         mock_delete.return_value = True
 
@@ -249,7 +299,7 @@ class TestDeleteCycle:
         mock_delete.return_value = False
 
         with pytest.raises(HTTPException) as exc:
-            await delete_cycle("nonexistent", TEST_USER_ID)
+            await delete_cycle("550e8400-e29b-41d4-a716-4466554400ff", TEST_USER_ID)
         assert exc.value.status_code == 404
 
 

--- a/backend/tests/test_cycle_service_integration.py
+++ b/backend/tests/test_cycle_service_integration.py
@@ -140,7 +140,7 @@ class TestGetCycleById:
 
     async def test_not_found(self):
         with pytest.raises(HTTPException) as exc:
-            await get_cycle_by_id("nonexistent-id", TEST_USER_ID)
+            await get_cycle_by_id("550e8400-e29b-41d4-a716-4466554400ff", TEST_USER_ID)
         assert exc.value.status_code == 404
 
     async def test_wrong_user_returns_404(self, existing_cycle):
@@ -161,7 +161,7 @@ class TestUpdateCycle:
     async def test_not_found(self):
         with pytest.raises(HTTPException) as exc:
             await update_cycle(
-                cycle_id="nonexistent",
+                cycle_id="550e8400-e29b-41d4-a716-4466554400ff",
                 user_id=TEST_USER_ID,
                 data={"end_date": date(2025, 6, 5)},
             )
@@ -210,7 +210,7 @@ class TestDeleteCycle:
 
     async def test_not_found(self):
         with pytest.raises(HTTPException) as exc:
-            await delete_cycle("nonexistent", TEST_USER_ID)
+            await delete_cycle("550e8400-e29b-41d4-a716-4466554400ff", TEST_USER_ID)
         assert exc.value.status_code == 404
 
     async def test_wrong_user_returns_404(self, existing_cycle):

--- a/backend/tests/test_symptom_service.py
+++ b/backend/tests/test_symptom_service.py
@@ -1,0 +1,140 @@
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.symptom_service import list_logs_by_cycle, create_log
+from tests.conftest import MockRow, TEST_USER_ID, TEST_CYCLE_ID, TEST_LOG_ID
+
+
+def _make_cycle_row(**overrides) -> MockRow:
+    from datetime import date, datetime
+    return MockRow({
+        "id": overrides.get("id", TEST_CYCLE_ID),
+        "user_id": overrides.get("user_id", TEST_USER_ID),
+        "start_date": overrides.get("start_date", date(2025, 6, 1)),
+        "end_date": overrides.get("end_date", date(2025, 6, 5)),
+        "created_at": overrides.get("created_at", datetime(2025, 6, 1, 12, 0, 0)),
+        "updated_at": overrides.get("updated_at", datetime(2025, 6, 1, 12, 0, 0)),
+    })
+
+
+def _make_log_row(**overrides) -> MockRow:
+    from datetime import date, datetime
+    return MockRow({
+        "id": overrides.get("id", TEST_LOG_ID),
+        "cycle_id": overrides.get("cycle_id", TEST_CYCLE_ID),
+        "date": overrides.get("date", date(2025, 6, 1)),
+        "flow_level": overrides.get("flow_level", "medium"),
+        "temperature": overrides.get("temperature", 36.5),
+        "notes": overrides.get("notes", None),
+        "created_at": overrides.get("created_at", datetime(2025, 6, 1, 12, 0, 0)),
+        "updated_at": overrides.get("updated_at", datetime(2025, 6, 1, 12, 0, 0)),
+    })
+
+
+class TestListLogsByCycleValidation:
+    async def test_empty_cycle_id_returns_400(self):
+        with pytest.raises(HTTPException) as exc:
+            await list_logs_by_cycle(cycle_id="", user_id=TEST_USER_ID)
+        assert exc.value.status_code == 400
+        assert "cycle_id" in exc.value.detail
+
+    async def test_invalid_uuid_returns_400(self):
+        with pytest.raises(HTTPException) as exc:
+            await list_logs_by_cycle(cycle_id="not-a-uuid", user_id=TEST_USER_ID)
+        assert exc.value.status_code == 400
+        assert "cycle_id" in exc.value.detail
+
+    async def test_short_invalid_uuid_returns_400(self):
+        with pytest.raises(HTTPException) as exc:
+            await list_logs_by_cycle(cycle_id="abc", user_id=TEST_USER_ID)
+        assert exc.value.status_code == 400
+
+    async def test_none_cycle_id_returns_400(self):
+        with pytest.raises(HTTPException) as exc:
+            await list_logs_by_cycle(cycle_id=None, user_id=TEST_USER_ID)
+        assert exc.value.status_code == 400
+
+
+class TestListLogsByCycle:
+    @patch("app.services.symptom_service.cycle_repo.get_cycle_by_id")
+    async def test_valid_uuid_cycle_not_found_returns_404(self, mock_get):
+        mock_get.return_value = None
+
+        with pytest.raises(HTTPException) as exc:
+            await list_logs_by_cycle(
+                cycle_id="550e8400-e29b-41d4-a716-4466554400aa",
+                user_id=TEST_USER_ID,
+            )
+        assert exc.value.status_code == 404
+
+    @patch("app.services.symptom_service.get_symptoms_by_log")
+    @patch("app.services.symptom_service.get_logs_by_cycle_paginated")
+    @patch("app.services.symptom_service.count_logs_by_cycle")
+    @patch("app.services.symptom_service.cycle_repo.get_cycle_by_id")
+    async def test_valid_uuid_returns_logs(
+        self, mock_get_cycle, mock_count, mock_logs, mock_symptoms
+    ):
+        mock_get_cycle.return_value = _make_cycle_row()
+        mock_count.return_value = 1
+        mock_logs.return_value = [_make_log_row()]
+        mock_symptoms.return_value = []
+
+        total, logs = await list_logs_by_cycle(
+            cycle_id=TEST_CYCLE_ID,
+            user_id=TEST_USER_ID,
+        )
+        assert total == 1
+        assert len(logs) == 1
+        assert logs[0]["id"] == TEST_LOG_ID
+
+
+class TestCreateLogValidation:
+    @patch("app.services.symptom_service.cycle_repo.get_cycle_by_id")
+    async def test_invalid_cycle_id_returns_400(self, mock_get):
+        with pytest.raises(HTTPException) as exc:
+            await create_log(
+                data={"cycle_id": "invalid", "date": "2025-06-01"},
+                user_id=TEST_USER_ID,
+            )
+        assert exc.value.status_code == 400
+        mock_get.assert_not_awaited()
+
+    @patch("app.services.symptom_service.cycle_repo.get_cycle_by_id")
+    async def test_empty_cycle_id_returns_400(self, mock_get):
+        with pytest.raises(HTTPException) as exc:
+            await create_log(
+                data={"cycle_id": "", "date": "2025-06-01"},
+                user_id=TEST_USER_ID,
+            )
+        assert exc.value.status_code == 400
+        mock_get.assert_not_awaited()
+
+
+class TestValidateUUIDHelper:
+    def test_validate_uuid_or_400_valid(self):
+        from app.core.validators import validate_uuid_or_400
+        validate_uuid_or_400(TEST_CYCLE_ID)
+
+    def test_validate_uuid_or_400_invalid(self):
+        from app.core.validators import validate_uuid_or_400
+
+        with pytest.raises(HTTPException) as exc:
+            validate_uuid_or_400("bad-uuid", "field")
+        assert exc.value.status_code == 400
+        assert "field" in exc.value.detail
+
+    def test_validate_uuid_or_400_empty(self):
+        from app.core.validators import validate_uuid_or_400
+
+        with pytest.raises(HTTPException) as exc:
+            validate_uuid_or_400("", "cycle_id")
+        assert exc.value.status_code == 400
+
+    def test_validate_uuid_or_400_none(self):
+        from app.core.validators import validate_uuid_or_400
+
+        with pytest.raises(HTTPException) as exc:
+            validate_uuid_or_400(None, "cycle_id")
+        assert exc.value.status_code == 400


### PR DESCRIPTION
- Crea app/core/validators.py con helper validate_uuid_or_400()
- Agrega validacion UUID en symptom_service.py (list_logs_by_cycle, create_log)
- Agrega validacion UUID en cycle_service.py (get, update, delete)
- Agrega validacion UUID en routers/symptoms.py y routers/cycles.py
- Crea tests/test_symptom_service.py (11 tests unitarios)
- Agrega tests UUID a test_cycle_service.py (+6 tests)
- Actualiza tests existentes: usa UUID validos en vez de 'nonexistent'
- Actualiza Docs/ISSUES.md: marca #64 como implementado
- Actualiza Docs/contextoopencode.md: Meriyei sin pendientes

Resuelve: #64 — DataError por UUID invalido/empty en PostgreSQL
Fix: typo sentinel-sdk → sentry-sdk en requirements.txt