### PR TITLE
[S10] fix: validacion UUID en endpoints + manejo JWKS + docs corregidos (#64, #70)

### DIFF
--- a/Docs/ISSUES.md
+++ b/Docs/ISSUES.md
@@ -353,9 +353,9 @@ PWA de salud menstrual privacy-first · React + FastAPI + ML
 
 | Estado | Cantidad | Issues |
 |--------|----------|--------|
-| ✅ Implementado | 6 | #68, #69, #70, #71, #72, #75 |
-| 🔧 Pendiente Daniel | 3 | #63, #66, #74 (verificar) |
-| 🔧 Pendiente Meriyei | 1 | #64 |
+| ✅ Implementado | 6 | #64, #68, #69, #70, #72, #75 |
+| ⚠️ Pendiente validación staging | 1 | #71 (necesita prueba contra Pooler real puerto 6543) |
+| 🔧 Pendiente Daniel | 2 | #63, #66 |
 | 🔧 Pendiente Madeleine | 3 | #65, #67, #73 (verificar) |
 | 🔧 Pendiente Joshua | 5 | #76, #77, #78, #79, #80 |
 
@@ -378,8 +378,8 @@ PWA de salud menstrual privacy-first · React + FastAPI + ML
 
 | Developer | Issues Sprint 1-9 | Issues Sprint 10 | Total |
 |-----------|:---:|:---:|:---:|
-| Daniel    | 22 | 3 | 25 |
-| Meriyei   | 19 | 1 | 20 |
+| Daniel    | 22 | 6 | 28 |
+| Meriyei   | 19 | 4 | 23 |
 | Madeleine | 13 | 3 | 16 |
 | Joshua    | 8  | 5 | 13 |
 

--- a/Docs/contextoopencode.md
+++ b/Docs/contextoopencode.md
@@ -177,7 +177,7 @@ Sección `lg:hidden` debajo del calendario: card de fase actual + grid 2-col (Fl
 
 ## 3. Bugfixes Backend
 
-### 3.1 — PgBouncer + asyncpg prepared statements (Meriyei + Daniel)
+### 3.1 — PgBouncer + asyncpg prepared statements (Daniel)
 
 **Problema:** `DuplicatePreparedStatementError` en cada query a BD vía Supabase pooler (puerto 6543).
 
@@ -188,7 +188,9 @@ engine = create_async_engine(DATABASE_URL, pool_pre_ping=True,
     connect_args={"statement_cache_size": 0})  # ← agregado
 ```
 
-### 3.2 — JWT ES256 vía JWKS (Meriyei + Daniel)
+**Estado:** ⚠️ Implementado, pendiente de validación en staging contra el Transaction Pooler real de Supabase (puerto 6543). SQLite no puede reproducir el error — requiere prueba de integración con despliegue real. Bloqueante para deploy a Render.
+
+### 3.2 — JWT ES256 vía JWKS (Daniel)
 
 **Problema:** `GET /cycles` → 401 incluso con token válido. Supabase emite tokens `ES256` (asimétrico) pero `security.py` solo validaba `HS256` (simétrico).
 
@@ -196,13 +198,15 @@ engine = create_async_engine(DATABASE_URL, pool_pre_ping=True,
 
 Ahora intenta HS256 primero (con `SUPABASE_JWT_SECRET`), y si falla, descarga la clave pública del JWKS de Supabase y valida con `ES256`/`RS256` vía `PyJWKClient`.
 
-### 3.3 — Catálogo de síntomas cacheado (Meriyei + Daniel)
+### 3.3 — Catálogo de síntomas cacheado (Daniel)
 
 **Problema:** `GET /symptoms` demoraba ~1.3s por latencia geográfica a Supabase (AWS us-west-2).
 
 **Archivo:** `backend/app/services/symptom_service.py`
 
 Cache en memoria del catálogo (30 síntomas estáticos). Resultado: **1.3s → 8ms** (162x más rápido).
+
+**Decisión de diseño:** El catálogo es estático (no cambia en runtime). No requiere invalidación — se carga una vez al inicio del proceso y se reinicia con cada deploy. Si en el futuro el catálogo se vuelve mutable, se necesitará un endpoint de invalidación o un TTL.
 
 ### 3.4 — Dependencias faltantes (Madeleine)
 
@@ -280,7 +284,7 @@ Puertos 5173/tcp y 8000/tcp abiertos vía `ufw` para acceso desde red local.
 
 | # | Título | Archivos |
 |---|--------|----------|
-| 64 | Validar `cycle_id` UUID antes de query en `list_logs_by_cycle` | `services/symptom_service.py`, `routers/symptoms.py` |
+| — | (ninguno pendiente) | #64 implementado, #69/#70/#71 corregidos por Daniel |
 
 ### 6.3 — Pendiente Madeleine
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -2,6 +2,7 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 import jwt
 from jwt import PyJWKClient
+from jwt.exceptions import PyJWKClientError
 
 from app.core.config import settings
 
@@ -47,7 +48,11 @@ async def get_current_user(token: str = Depends(oauth2_scheme)) -> dict:
                 algorithms=["ES256", "RS256"],
                 audience="authenticated",
             )
+        except PyJWKClientError:
+            raise credentials_exception
         except jwt.PyJWTError:
+            raise credentials_exception
+        except Exception:
             raise credentials_exception
 
     user_id: str = payload.get("sub")

--- a/backend/app/services/symptom_service.py
+++ b/backend/app/services/symptom_service.py
@@ -20,6 +20,8 @@ from app.repositories.symptom_repo import (
     remove_all_symptoms_from_log,
 )
 
+# Catálogo de síntomas es estático (30 registros), no cambia en runtime.
+# No requiere invalidación: se carga una vez al inicio y se reinicia con cada deploy.
 _catalog_cache: list[dict] | None = None
 
 

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,0 +1,98 @@
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+from fastapi import HTTPException
+from jwt.exceptions import PyJWKClientError
+
+from app.core.security import get_current_user
+
+
+class TestJWTJWKSErrorHandling:
+    @patch("app.core.security._get_jwks_client")
+    @patch("jwt.decode")
+    async def test_jwks_unreachable_returns_401(self, mock_decode, mock_jwks):
+        mock_decode.side_effect = jwt.PyJWTError("HS256 fallo")
+
+        mock_client = MagicMock()
+        mock_client.get_signing_key_from_jwt.side_effect = PyJWKClientError(
+            "No se pudo conectar al JWKS"
+        )
+        mock_jwks.return_value = mock_client
+
+        with pytest.raises(HTTPException) as exc:
+            await get_current_user(token="fake-token")
+        assert exc.value.status_code == 401
+        assert exc.value.detail == "Token inv\u00e1lido o expirado"
+
+    @patch("app.core.security._get_jwks_client")
+    @patch("jwt.decode")
+    async def test_jwks_invalid_key_returns_401(self, mock_decode, mock_jwks):
+        mock_decode.side_effect = jwt.PyJWTError("HS256 fallo")
+
+        mock_client = MagicMock()
+        mock_client.get_signing_key_from_jwt.side_effect = jwt.PyJWKError(
+            "Key not found"
+        )
+        mock_jwks.return_value = mock_client
+
+        with pytest.raises(HTTPException) as exc:
+            await get_current_user(token="fake-token")
+        assert exc.value.status_code == 401
+        assert exc.value.detail == "Token inv\u00e1lido o expirado"
+
+    @patch("app.core.security._get_jwks_client")
+    @patch("jwt.decode")
+    async def test_jwks_decode_fails_returns_401(self, mock_decode, mock_jwks):
+        mock_decode.side_effect = jwt.PyJWTError("HS256 fallo")
+
+        mock_client = MagicMock()
+        mock_signing_key = MagicMock()
+        mock_signing_key.key = "fake-key"
+        mock_client.get_signing_key_from_jwt.return_value = mock_signing_key
+        mock_jwks.return_value = mock_client
+
+        mock_decode.side_effect = [
+            jwt.PyJWTError("HS256 fallo"),
+            jwt.PyJWTError("ES256 fallo"),
+        ]
+
+        with pytest.raises(HTTPException) as exc:
+            await get_current_user(token="fake-token")
+        assert exc.value.status_code == 401
+        assert exc.value.detail == "Token inv\u00e1lido o expirado"
+
+    @patch("app.core.security._get_jwks_client")
+    @patch("jwt.decode")
+    async def test_no_sub_in_payload_returns_401(self, mock_decode, mock_jwks):
+        mock_decode.side_effect = jwt.PyJWTError("HS256 fallo")
+
+        mock_client = MagicMock()
+        mock_signing_key = MagicMock()
+        mock_signing_key.key = "fake-key"
+        mock_client.get_signing_key_from_jwt.return_value = mock_signing_key
+        mock_jwks.return_value = mock_client
+
+        mock_decode.side_effect = [
+            jwt.PyJWTError("HS256 fallo"),
+            {"aud": "authenticated"},
+        ]
+
+        with pytest.raises(HTTPException) as exc:
+            await get_current_user(token="fake-token")
+        assert exc.value.status_code == 401
+
+    @patch("app.core.security._get_jwks_client")
+    @patch("jwt.decode")
+    async def test_jwks_generic_exception_returns_401(self, mock_decode, mock_jwks):
+        mock_decode.side_effect = jwt.PyJWTError("HS256 fallo")
+
+        mock_client = MagicMock()
+        mock_client.get_signing_key_from_jwt.side_effect = RuntimeError(
+            "Unexpected error"
+        )
+        mock_jwks.return_value = mock_client
+
+        with pytest.raises(HTTPException) as exc:
+            await get_current_user(token="fake-token")
+        assert exc.value.status_code == 401


### PR DESCRIPTION
### #64 — Validación UUID (branch A, ya mergeada parcialmente)
- `app/core/validators.py`: helper `validate_uuid_or_400()`
- Validación en GET/PUT/DELETE /cycles/{id} y GET/POST /daily-logs
- 18 tests nuevos (test_symptom_service.py + test_cycle_service.py)

### #70 — Seguridad JWT (branch B)
- Manejo de excepción PyJWKClient unreachable → 401
- 5 tests de seguridad (test_security.py)

### Docs corregidos
- Atribución real: #69/#70/#71 → Daniel, no "Meriyei+Daniel"
- Tabla distribución: Meriyei 4, Daniel 6
- #71: pendiente validación staging (Pooler real)
- #69: documentada decisión de cache estático

### Tests
- 206 passed, 0 failures
- SQLite in-memory + mocks — nunca Supabase real