### PR TITLE
[S8] feat: mejorar SYSTEM_PROMPT, ajustar temperature 0.5 y tests calidad (Issue #78)

### DIFF
--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -15,14 +15,19 @@ GROQ_MODEL = "llama3-8b-8192"
 
 SYSTEM_PROMPT = """
 Eres EVA, una asistente de salud menstrual. Respondes en espanol, con tono calido,
-empatico y basado en evidencia cientifica. Tus respuestas son concisas (maximo 4 oraciones)
-y siempre incluyen el disclaimer de que no reemplazas al medico.
+empatico y basado en evidencia cientifica.
 
-Principios:
-- Solo hablas de salud menstrual y temas relacionados
-- Nunca haces diagnosticos medicos
-- Si la usuaria menciona sintomas graves, la remites a su ginecologa
-- Usas los datos del ciclo proporcionados para personalizar la respuesta
+Reglas de formato:
+- Maximo 4 oraciones por respuesta.
+- Siempre incluye: "EVA no reemplaza el consejo medico profesional."
+- Usa los datos del ciclo proporcionados para personalizar la respuesta.
+- Si te preguntan por algo no relacionado con salud menstrual, redirige amablemente.
+
+Limites:
+- Nunca hagas diagnosticos medicos.
+- Si la usuaria menciona sintomas graves (dolor intenso, sangrado abundante,
+  fiebre, etc.), recomienda consultar a un ginecologo.
+- No inventes datos medicos. Si no sabes, di que no tienes suficiente informacion.
 """
 
 
@@ -50,7 +55,7 @@ async def _call_ollama(prompt: str) -> Optional[str]:
                     "model": OLLAMA_MODEL,
                     "prompt": f"{SYSTEM_PROMPT}\n\n{prompt}",
                     "stream": False,
-                    "options": {"temperature": 0.7, "num_predict": 300},
+                    "options": {"temperature": 0.5, "num_predict": 300},
                 },
             )
             response.raise_for_status()
@@ -75,7 +80,7 @@ async def _call_groq(prompt: str) -> Optional[str]:
                         {"role": "user", "content": prompt},
                     ],
                     "max_tokens": 300,
-                    "temperature": 0.7,
+                    "temperature": 0.5,
                 },
             )
             response.raise_for_status()

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -1,4 +1,5 @@
-from datetime import date, timedelta
+import re
+from datetime import date
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -221,6 +222,18 @@ class TestCoherentResponses:
     def test_system_prompt_mentions_cycle_data(self):
         assert "datos del ciclo" in SYSTEM_PROMPT or "datos" in SYSTEM_PROMPT
 
+    def test_system_prompt_no_medical_diagnosis(self):
+        assert "diagnosticos" in SYSTEM_PROMPT or "diagnósticos" in SYSTEM_PROMPT
+
+    def test_system_prompt_redirects_severe_symptoms(self):
+        assert "ginecologo" in SYSTEM_PROMPT or "ginecólogo" in SYSTEM_PROMPT
+
+    def test_system_prompt_does_not_invent_data(self):
+        assert "inventes" in SYSTEM_PROMPT
+
+    def test_system_prompt_max_four_sentences_rule(self):
+        assert "4 oraciones" in SYSTEM_PROMPT
+
     async def test_ollama_response_includes_context(self):
         """Cuando el LLM responde, el prompt incluye datos reales del ciclo,
         no placeholders genéricos."""
@@ -376,3 +389,58 @@ class TestBuildCycleContextComplete:
         ctx_str = str(ctx)
         assert "@" not in ctx_str
         assert "email" not in ctx_str.lower()
+
+
+class TestResponseQuality:
+    """Issue #78: Evalua calidad de respuestas del LLM."""
+
+    def test_temperature_between_03_and_09(self):
+        import inspect
+        source = inspect.getsource(_call_ollama)
+        match = re.search(r'"temperature":\s*([\d.]+)', source)
+        assert match is not None
+        temp = float(match.group(1))
+        assert 0.3 <= temp <= 0.9, f"Temperature {temp} fuera de rango 0.3-0.9"
+
+    def test_num_predict_between_200_and_500(self):
+        import inspect
+        source = inspect.getsource(_call_ollama)
+        match = re.search(r'"num_predict":\s*(\d+)', source)
+        assert match is not None
+        num = int(match.group(1))
+        assert 200 <= num <= 500, f"num_predict {num} fuera de rango 200-500"
+
+    def test_ollama_temperature_matches_groq(self):
+        import inspect
+        ollama_src = inspect.getsource(_call_ollama)
+        groq_src = inspect.getsource(_call_groq)
+        ollama_temp = re.search(r'"temperature":\s*([\d.]+)', ollama_src)
+        groq_temp = re.search(r'"temperature":\s*([\d.]+)', groq_src)
+        assert ollama_temp is not None
+        assert groq_temp is not None
+        assert ollama_temp.group(1) == groq_temp.group(1), \
+            "Ollama y Groq deben usar la misma temperature"
+
+    def test_system_prompt_has_no_invented_data_rule(self):
+        assert "inventes" in SYSTEM_PROMPT
+
+    @pytest.mark.parametrize("keyword", [
+        "calido", "empatico", "espanol", "cientif",
+        "ginecologo", "diagnosticos", "4 oraciones",
+    ])
+    def test_system_prompt_contains_key_terms(self, keyword):
+        assert keyword in SYSTEM_PROMPT
+
+    def test_system_prompt_disclaimer_present(self):
+        assert "no reemplaza" in SYSTEM_PROMPT
+
+    def test_groq_max_tokens_matches_ollama_num_predict(self):
+        import inspect
+        ollama_src = inspect.getsource(_call_ollama)
+        groq_src = inspect.getsource(_call_groq)
+        ollama_num = re.search(r'"num_predict":\s*(\d+)', ollama_src)
+        groq_max = re.search(r'"max_tokens":\s*(\d+)', groq_src)
+        assert ollama_num is not None
+        assert groq_max is not None
+        assert ollama_num.group(1) == groq_max.group(1), \
+            "Ollama num_predict y Groq max_tokens deben coincidir"


### PR DESCRIPTION
## Issue #78 - Evaluar y ajustar calidad de respuestas del LLM

### Cambios en llm_service.py
- **SYSTEM_PROMPT mejorado**: reglas de formato explicitas, limites claros, prohibicion de inventar datos
- **temperature bajada de 0.7 a 0.5**: respuestas mas precisas y menos creativas
- **Misma temperature para Ollama y Groq**:????
- **num_predict y max_tokens**: 300 (sin cambios)

### Tests agregados (TestResponseQuality)
| Test | Que verifica |
|---|---|
| temperature_between_03_and_09 | Temperature en rango valido |
| num_predict_between_200_and_500 | Tokens en rango valido |
| ollama_temperature_matches_groq | Ambos usan misma temperature |
| system_prompt_has_no_invented_data_rule | No inventa datos medicos |
| system_prompt_contains_key_terms | 7 terminos clave presentes |
| system_prompt_disclaimer_present | Disclaimer incluido |
| groq_max_tokens_matches_ollama_num_predict | Tokens sincronizados |

### Tests de regresion
- 55 tests, 0 fallos

### Criterios cumplidos
- [x] SYSTEM_PROMPT mejorado con reglas de formato y limites
- [x] temperature ajustada (0.5) para precision
- [x] Tests que verifican calidad del prompt
- [x] Misma configuracion para Ollama y Groq