### PR TITLE
[S8] feat: health check de Ollama en startup + verify_ml_env mejorado (Issue #80)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,5 @@
+import logging
+
 import sentry_sdk
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -42,6 +44,21 @@ def _scrub_sentry_event(event: dict) -> dict:
     return event
 
 
+async def _check_ollama_on_startup() -> None:
+    try:
+        from app.services.llm_service import check_ollama_health
+
+        health = await check_ollama_health()
+        if health["status"] == "ok":
+            logging.info(f"Startup OK — {health['message']}")
+        elif health["status"] == "no_model":
+            logging.warning(f"Startup WARN — {health['message']}")
+        else:
+            logging.warning(f"Startup WARN — {health['message']}")
+    except Exception as e:
+        logging.warning(f"Startup WARN — No se pudo verificar Ollama: {e}")
+
+
 app = FastAPI(
     title="EVA API",
     description="Backend de EVA — Plataforma de Salud Menstrual",
@@ -65,6 +82,7 @@ app.add_middleware(
 @app.on_event("startup")
 async def startup_event() -> None:
     await preload_jwks()
+    await _check_ollama_on_startup()
 
 app.add_middleware(SecurityHeadersMiddleware)
 

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import date, timedelta
 from typing import Optional
 
@@ -154,6 +155,53 @@ async def build_cycle_context(user_id: str, context_cycles: int = 6) -> dict:
         "intensidad_actual": intensidad_actual or "moderada",
         "dias_hasta_siguiente": days_until_next,
     }
+
+
+logger = logging.getLogger(__name__)
+
+
+OLLAMA_TIMEOUT = 5.0
+
+
+async def check_ollama_health() -> dict:
+    """Verifica si Ollama esta disponible y que modelos tiene cargados.
+
+    Retorna dict con status, models y message.
+    No lanza excepcion — siempre retorna un dict descriptivo.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=OLLAMA_TIMEOUT) as client:
+            response = await client.get(f"{OLLAMA_BASE_URL}/api/tags")
+            if response.status_code == 200:
+                data = response.json()
+                models = [m["name"] for m in data.get("models", [])]
+                has_mistral = any("mistral" in m for m in models)
+                return {
+                    "status": "ok" if has_mistral else "no_model",
+                    "models": models,
+                    "message": (
+                        f"Ollama disponible. Modelos: {models}"
+                        if has_mistral
+                        else f"Ollama disponible pero modelo mistral no encontrado. Modelos: {models}"
+                    ),
+                }
+            return {
+                "status": "error",
+                "models": [],
+                "message": f"Ollama respondio con status {response.status_code}",
+            }
+    except httpx.ConnectError:
+        return {
+            "status": "unavailable",
+            "models": [],
+            "message": "Ollama no esta corriendo. Ejecuta: ollama serve",
+        }
+    except Exception as e:
+        return {
+            "status": "error",
+            "models": [],
+            "message": f"Error verificando Ollama: {e}",
+        }
 
 
 async def get_insight(question: str, cycle_context: dict) -> dict:

--- a/backend/scripts/verify_ml_env.py
+++ b/backend/scripts/verify_ml_env.py
@@ -1,9 +1,10 @@
 """Verifica que el entorno local de ML esté correctamente configurado."""
 
 import importlib
+import json
 import sys
-import subprocess
 from pathlib import Path
+from urllib.request import urlopen
 
 
 REQUIRED_PACKAGES = {
@@ -84,22 +85,27 @@ def check_joblib() -> bool:
 
 def check_ollama() -> bool:
     try:
-        result = subprocess.run(
-            ["ollama", "list"],
-            capture_output=True, text=True, timeout=15
-        )
-        if result.returncode == 0:
-            models = [l.split()[0] for l in result.stdout.strip().split("\n")[1:] if l.strip()]
-            print(f"  [OK] Ollama disponible. Modelos: {models}")
+        response = urlopen("http://localhost:11434/api/tags", timeout=5)
+        if response.status == 200:
+            data = json.loads(response.read().decode())
+            models = [m["name"] for m in data.get("models", [])]
+            has_mistral = any("mistral" in m for m in models)
+            if has_mistral:
+                print(f"  [OK] Ollama disponible. Modelos: {models}")
+            else:
+                print(f"  [WARN] Ollama disponible pero mistral no cargado. Modelos: {models}")
             return True
         else:
-            print(f"  [WARN] Ollama no responde — {result.stderr.strip()}")
+            print(f"  [WARN] Ollama respondio con status {response.status}")
             return False
-    except FileNotFoundError:
-        print("  [WARN] Ollama no encontrado en PATH")
-        return False
-    except subprocess.TimeoutExpired:
-        print("  [WARN] Ollama no responde (timeout)")
+    except Exception as e:
+        reason = str(e)
+        if "No connection" in reason or "Connection refused" in reason:
+            print("  [WARN] Ollama no esta corriendo. Ejecuta: ollama serve")
+        elif "Name or service not known" in reason:
+            print("  [WARN] Ollama no encontrado. Descarga: https://ollama.ai")
+        else:
+            print(f"  [WARN] Ollama no responde — {reason}")
         return False
 
 


### PR DESCRIPTION
## Issue #80 - Agregar health check de Ollama en startup de la app

### Cambios

**`backend/app/services/llm_service.py`**
- `check_ollama_health()`: funcion async que verifica Ollama via HTTP GET /api/tags
- Retorna dict con status (ok/no_model/unavailable/error), lista de modelos y mensaje
- Timeout de 5s, no bloquea

**`backend/app/main.py`**
- Startup event ahora llama a `_check_ollama_on_startup()`
- Loggea INFO si Ollama OK, WARNING si no esta disponible (no bloquea el arranque)

**`backend/scripts/verify_ml_env.py`**
- check_ollama() ahora usa HTTP en vez de subprocess (mas confiable)
- Mensajes de error mas claros (ollama serve, descarga, etc.)

### Criterios cumplidos
- [x] check_ollama_health() en llm_service.py (GET /api/tags)
- [x] Llamada en evento startup de FastAPI
- [x] Si Ollama no responde, log WARNING pero no bloquea
- [x] verify_ml_env.py actualizado con HTTP check